### PR TITLE
feat: 팝업 컴포넌트 추가

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className={pretendard.variable}>
         <AppProviders enableMocking={enableMocking}>{children}</AppProviders>
-        <div id="modal-root"/>
+        <div id="modal-root" />
       </body>
     </html>
   );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,6 +12,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className={pretendard.variable}>
         <AppProviders enableMocking={enableMocking}>{children}</AppProviders>
+        <div id="modal-root"/>
       </body>
     </html>
   );

--- a/apps/web/src/components/buttons/button/Button.tsx
+++ b/apps/web/src/components/buttons/button/Button.tsx
@@ -22,9 +22,16 @@ const Button = ({
   size = 'medium',
   disabled = false,
   variant = 'primary',
+  ...rest
 }: ButtonProps) => {
   return (
-    <S.Button size={size} variant={variant} onClick={onClick} disabled={disabled}>
+    <S.Button
+      size={size}
+      variant={variant}
+      onClick={onClick}
+      disabled={disabled}
+      {...rest}
+    >
       {text}
     </S.Button>
   );

--- a/apps/web/src/components/buttons/circleButton/CircleButton.tsx
+++ b/apps/web/src/components/buttons/circleButton/CircleButton.tsx
@@ -7,9 +7,9 @@ interface CircleButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement
   onClick: () => void;
 }
 
-const CircleButton = ({ children, onClick }: CircleButtonProps) => {
+const CircleButton = ({ children, onClick, ...rest }: CircleButtonProps) => {
   return (
-    <S.Wrapper type="button" onClick={onClick}>
+    <S.Wrapper type="button" onClick={onClick} {...rest}>
       {children}
     </S.Wrapper>
   );

--- a/apps/web/src/components/buttons/floatingButton/FloatingButton.styles.ts
+++ b/apps/web/src/components/buttons/floatingButton/FloatingButton.styles.ts
@@ -9,7 +9,7 @@ export const Wrapper = styled.button`
   padding: 10px 16px;
   border: 1px solid ${({ theme }) => theme.colors.blueWhite.border10};
   background: ${({ theme }) => theme.colors.blueWhite.bg5};
-  ${({ theme }) => theme.effects.backdropBlur[25]};
+  backdrop-filter: ${({ theme }) => theme.effects.backdropBlur[25]};
   border-radius: 99px;
 `;
 

--- a/apps/web/src/components/buttons/floatingButton/FloatingButton.tsx
+++ b/apps/web/src/components/buttons/floatingButton/FloatingButton.tsx
@@ -9,9 +9,9 @@ interface FloatingButtonProps {
   icon?: React.ReactNode;
 }
 
-const FloatingButton = ({ text, icon, onClick }: FloatingButtonProps) => {
+const FloatingButton = ({ text, icon, onClick, ...rest }: FloatingButtonProps) => {
   return (
-    <S.Wrapper onClick={onClick}>
+    <S.Wrapper onClick={onClick} {...rest}>
       {icon}
       <S.TextContainer>{text}</S.TextContainer>
     </S.Wrapper>

--- a/apps/web/src/components/buttons/textButton/TextButton.tsx
+++ b/apps/web/src/components/buttons/textButton/TextButton.tsx
@@ -17,9 +17,16 @@ const TextButton = ({
   onClick,
   variant = 'default',
   disabled = false,
+  ...rest
 }: TextButtonProps) => {
   return (
-    <S.Wrapper type="button" onClick={onClick} variant={variant} disabled={disabled}>
+    <S.Wrapper
+      type="button"
+      onClick={onClick}
+      variant={variant}
+      disabled={disabled}
+      {...rest}
+    >
       {text}
     </S.Wrapper>
   );

--- a/apps/web/src/components/popup/BackDrop.tsx
+++ b/apps/web/src/components/popup/BackDrop.tsx
@@ -1,0 +1,11 @@
+import * as S from './Popup.styles';
+
+interface BackdropProps {
+  onClick?: () => void;
+}
+
+const Backdrop = ({ onClick }: BackdropProps) => {
+  return <S.Backdrop onClick={onClick} />;
+};
+
+export default Backdrop;

--- a/apps/web/src/components/popup/Popup.styles.ts
+++ b/apps/web/src/components/popup/Popup.styles.ts
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  position: fixed;
+  inset: 0;
+
+  z-index: ${({ theme }) => theme.zIndex.overlay};
+
+  isolation: isolate;
+  pointer-events: none;
+`;
+
+export const Backdrop = styled.div`
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
+`;
+
+export const Layer = styled.div`
+  position: absolute;
+  inset: 0;
+
+  pointer-events: auto;
+
+  display: flex;
+
+  align-items: center;
+  justify-content: center;
+`;

--- a/apps/web/src/components/popup/Popup.styles.ts
+++ b/apps/web/src/components/popup/Popup.styles.ts
@@ -4,7 +4,7 @@ export const Root = styled.div`
   position: fixed;
   inset: 0;
 
-  z-index: ${({ theme }) => theme.zIndex.overlay};
+  z-index: ${({ theme }) => theme.zIndex.popupRoot};
 
   isolation: isolate;
   pointer-events: none;

--- a/apps/web/src/components/popup/PopupLayer.tsx
+++ b/apps/web/src/components/popup/PopupLayer.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import * as S from './Popup.styles';
+
+interface PopupLayerProps {
+  children: ReactNode;
+}
+
+const PopupLayer = ({ children }: PopupLayerProps) => {
+  return <S.Layer>{children}</S.Layer>;
+};
+
+export default PopupLayer;

--- a/apps/web/src/components/popup/PopupRoot.tsx
+++ b/apps/web/src/components/popup/PopupRoot.tsx
@@ -1,0 +1,12 @@
+import { createPortal } from 'react-dom';
+import * as S from './Popup.styles';
+
+interface PopupRootProps {
+  children: React.ReactNode;
+}
+
+const PopupRoot = ({ children }: PopupRootProps) => {
+  return createPortal(<S.Root>{children}</S.Root>, document.body);
+};
+
+export default PopupRoot;

--- a/apps/web/src/components/popup/PopupRoot.tsx
+++ b/apps/web/src/components/popup/PopupRoot.tsx
@@ -1,12 +1,19 @@
+'use client';
+
 import { createPortal } from 'react-dom';
+import { useEffect, useState } from 'react';
 import * as S from './Popup.styles';
 
-interface PopupRootProps {
-  children: React.ReactNode;
-}
+const PopupRoot = ({ children }: { children: React.ReactNode }) => {
+  const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
 
-const PopupRoot = ({ children }: PopupRootProps) => {
-  return createPortal(<S.Root>{children}</S.Root>, document.body);
+  useEffect(() => {
+    setModalRoot(document.getElementById('modal-root'));
+  }, []);
+
+  if (!modalRoot) return null;
+
+  return createPortal(<S.Root>{children}</S.Root>, modalRoot);
 };
 
 export default PopupRoot;

--- a/apps/web/src/components/popup/modal/Modal.stories.tsx
+++ b/apps/web/src/components/popup/modal/Modal.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Button from '@/components/buttons/button/Button';
+import TextButton from '@/components/buttons/textButton/TextButton';
+import Modal from '@/components/popup/modal/Modal';
+import usePopup from '@/hooks/usePopup';
+
+const meta: Meta<typeof Modal> = {
+  title: 'Components/Popup/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  render: () => {
+    const { isOpen, handleOpen, handleClose } = usePopup();
+
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <Button text="모달 열기" onClick={handleOpen} />
+        <Modal isOpen={isOpen} onClose={handleClose}>
+          <Modal.Content>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+              <h2>Modal Example</h2>
+              <p>usePopup + Modal.Content로 동작하는 기본 예시입니다.</p>
+            </div>
+            <Modal.Footer>
+              <TextButton text="취소" onClick={handleClose} style={{ flex: 1 }} />
+              <TextButton
+                text="삭제하기"
+                variant="negative"
+                onClick={handleClose}
+                style={{ flex: 1 }}
+              />
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal>
+      </div>
+    );
+  },
+};

--- a/apps/web/src/components/popup/modal/Modal.styles.ts
+++ b/apps/web/src/components/popup/modal/Modal.styles.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+export const Content = styled.div`
+  /* TODO: 추후 반응형 디자인에 따른 width, height 설정 필요 */
+  min-width: 280px;
+  max-width: calc(100% - 32px);
+  max-height: calc(100% - 32px);
+  padding: 24px;
+  background: ${({ theme }) => theme.colors.gray[1000]};
+  border: 1px solid ${({ theme }) => theme.colors.blueWhite.border10};
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 24px;
+`;
+
+export const Footer = styled.footer`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;

--- a/apps/web/src/components/popup/modal/Modal.tsx
+++ b/apps/web/src/components/popup/modal/Modal.tsx
@@ -1,0 +1,44 @@
+import PopupRoot from '../PopupRoot';
+import PopupLayer from '../PopupLayer';
+import Backdrop from '../BackDrop';
+import * as S from './Modal.styles';
+
+interface ModalProps {
+  /** 모달 열림 상태 */
+  isOpen: boolean;
+  /** 모달 닫는 함수 */
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+interface ModalContentProps {
+  children: React.ReactNode;
+}
+
+const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <PopupRoot>
+      <Backdrop onClick={onClose} />
+      <PopupLayer>{children}</PopupLayer>
+    </PopupRoot>
+  );
+};
+
+const ModalContent = ({ children }: ModalContentProps) => {
+  return (
+    <S.Content role="dialog" aria-modal="true">
+      {children}
+    </S.Content>
+  );
+};
+
+const ModalFooter = ({ children }: { children: React.ReactNode }) => {
+  return <S.Footer>{children}</S.Footer>;
+};
+
+Modal.Content = ModalContent;
+Modal.Footer = ModalFooter;
+
+export default Modal;

--- a/apps/web/src/components/popup/modal/Modal.tsx
+++ b/apps/web/src/components/popup/modal/Modal.tsx
@@ -2,6 +2,7 @@ import PopupRoot from '../PopupRoot';
 import PopupLayer from '../PopupLayer';
 import Backdrop from '../BackDrop';
 import * as S from './Modal.styles';
+import { ReactElement } from 'react';
 
 interface ModalProps {
   /** 모달 열림 상태 */
@@ -15,7 +16,12 @@ interface ModalContentProps {
   children: React.ReactNode;
 }
 
-const Modal = ({ isOpen, onClose, children }: ModalProps) => {
+type ModalComponent = ((props: ModalProps) => ReactElement | null) & {
+  Content: (props: ModalContentProps) => ReactElement;
+  Footer: (props: { children: React.ReactNode }) => ReactElement;
+};
+
+const Modal: ModalComponent = ({ isOpen, onClose, children }: ModalProps) => {
   if (!isOpen) return null;
 
   return (

--- a/apps/web/src/components/popup/overlay/Overlay.stories.tsx
+++ b/apps/web/src/components/popup/overlay/Overlay.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Button from '@/components/buttons/button/Button';
+import TextButton from '@/components/buttons/textButton/TextButton';
+import Overlay from '@/components/popup/overlay/Overlay';
+import usePopup from '@/hooks/usePopup';
+
+const meta: Meta<typeof Overlay> = {
+  title: 'Components/Popup/Overlay',
+  component: Overlay,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Overlay>;
+
+export const Default: Story = {
+  render: () => {
+    const { isOpen, handleOpen, handleClose } = usePopup({
+      closeOnEscape: false,
+      lockScroll: false,
+    });
+
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <Button text="오버레이 열기" onClick={handleOpen} />
+        <Overlay isOpen={isOpen} onClose={handleClose}>
+          <Overlay.Content>
+            <div>
+              <h2>Overlay Example</h2>
+              <p>usePopup + Overlay.Content로 동작하는 기본 예시입니다.</p>
+            </div>
+            <Overlay.Footer>
+              <TextButton text="닫기" onClick={handleClose} style={{ flex: 1 }} />
+              <TextButton
+                text="확인"
+                variant="primary"
+                onClick={handleClose}
+                style={{ flex: 1 }}
+              />
+            </Overlay.Footer>
+          </Overlay.Content>
+        </Overlay>
+      </div>
+    );
+  },
+};
+
+export const Custom: Story = {
+  render: () => {
+    const { isOpen, handleOpen, handleClose } = usePopup({
+      closeOnEscape: false,
+      lockScroll: false,
+    });
+
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <Button text="오버레이 열기" onClick={handleOpen} />
+        <Overlay isOpen={isOpen} onClose={handleClose}>
+          <Overlay.Content>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <h3 style={{ fontSize: 18, fontWeight: 700 }}>앨범 초대 링크 공유하기</h3>
+
+              <ul
+                style={{
+                  paddingLeft: 16,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 6,
+                  fontSize: 14,
+                  color: 'white',
+                }}
+              >
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+                <li>김야뿌</li>
+              </ul>
+            </div>
+
+            <Overlay.Footer>
+              <TextButton text="닫기" onClick={handleClose} style={{ flex: 1 }} />
+              <TextButton
+                text="확인"
+                variant="primary"
+                onClick={handleClose}
+                style={{ flex: 1 }}
+              />
+            </Overlay.Footer>
+          </Overlay.Content>
+        </Overlay>
+      </div>
+    );
+  },
+};

--- a/apps/web/src/components/popup/overlay/Overlay.styles.ts
+++ b/apps/web/src/components/popup/overlay/Overlay.styles.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export const Content = styled.div`
+  /* TODO: 추후 반응형 디자인에 따른 width, height 설정 필요 */
+  min-width: 280px;
+  max-width: calc(100% - 32px);
+  max-height: calc(100% - 32px);
+  padding: 24px;
+  background: ${({ theme }) => theme.colors.blueWhite.bg8};
+  backdrop-filter: ${({ theme }) => theme.effects.backdropBlur[25]};
+  border: 1px solid ${({ theme }) => theme.colors.blueWhite.border10};
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 24px;
+`;
+
+export const Footer = styled.footer`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;

--- a/apps/web/src/components/popup/overlay/Overlay.tsx
+++ b/apps/web/src/components/popup/overlay/Overlay.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from 'react';
+import PopupRoot from '../PopupRoot';
+import PopupLayer from '../PopupLayer';
+import Backdrop from '../BackDrop';
+import * as S from './Overlay.styles';
+
+interface OverlayProps {
+  /** 오버레이 열림 상태 */
+  isOpen: boolean;
+  /** 오버레이 닫는 함수 */
+  onClose?: () => void;
+  children?: ReactNode;
+}
+
+interface OverlayContentProps {
+  children: React.ReactNode;
+}
+
+const Overlay = ({ isOpen, onClose, children }: OverlayProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <PopupRoot>
+      <Backdrop onClick={onClose} />
+      <PopupLayer>{children}</PopupLayer>
+    </PopupRoot>
+  );
+};
+
+const OverlayContent = ({ children }: OverlayContentProps) => {
+  return (
+    <S.Content role="dialog" aria-modal="true">
+      {children}
+    </S.Content>
+  );
+};
+
+const OverlayFooter = ({ children }: { children: React.ReactNode }) => {
+  return <S.Footer>{children}</S.Footer>;
+};
+
+Overlay.Content = OverlayContent;
+Overlay.Footer = OverlayFooter;
+
+export default Overlay;

--- a/apps/web/src/components/popup/overlay/Overlay.tsx
+++ b/apps/web/src/components/popup/overlay/Overlay.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import PopupRoot from '../PopupRoot';
 import PopupLayer from '../PopupLayer';
 import Backdrop from '../BackDrop';
@@ -16,7 +16,12 @@ interface OverlayContentProps {
   children: React.ReactNode;
 }
 
-const Overlay = ({ isOpen, onClose, children }: OverlayProps) => {
+type OverlayComponent = ((props: OverlayProps) => ReactElement | null) & {
+  Content: (props: OverlayContentProps) => ReactElement;
+  Footer: (props: { children: React.ReactNode }) => ReactElement;
+};
+
+const Overlay: OverlayComponent = ({ isOpen, onClose, children }: OverlayProps) => {
   if (!isOpen) return null;
 
   return (

--- a/apps/web/src/hooks/useEscapeKeyClose.ts
+++ b/apps/web/src/hooks/useEscapeKeyClose.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+interface UseEscapeKeyCloseProps {
+  closeOnEscape: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const useEscapeKeyClose = ({
+  closeOnEscape,
+  isOpen,
+  onClose,
+}: UseEscapeKeyCloseProps) => {
+  useEffect(() => {
+    if (!closeOnEscape) return;
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+
+    addEventListener('keyup', handleKeyDown);
+
+    return () => {
+      removeEventListener('keyup', handleKeyDown);
+    };
+  }, [isOpen, closeOnEscape, onClose]);
+};
+
+export default useEscapeKeyClose;

--- a/apps/web/src/hooks/useEscapeKeyClose.ts
+++ b/apps/web/src/hooks/useEscapeKeyClose.ts
@@ -19,10 +19,10 @@ const useEscapeKeyClose = ({
       if (e.key === 'Escape') onClose();
     };
 
-    addEventListener('keyup', handleKeyDown);
+    addEventListener('keydown', handleKeyDown);
 
     return () => {
-      removeEventListener('keyup', handleKeyDown);
+      removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen, closeOnEscape, onClose]);
 };

--- a/apps/web/src/hooks/usePopup.ts
+++ b/apps/web/src/hooks/usePopup.ts
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import useEscapeKeyClose from './useEscapeKeyClose';
+import useScrollLock from './useScrollLock';
+
+interface UsePopupOptions {
+  initialOpen?: boolean;
+  closeOnEscape?: boolean;
+  lockScroll?: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+const usePopup = ({
+  initialOpen = false,
+  closeOnEscape = true,
+  lockScroll = true,
+  onOpen,
+  onClose,
+}: UsePopupOptions = {}) => {
+  const [isOpen, setIsOpen] = useState(initialOpen);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+    onOpen?.();
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    onClose?.();
+  };
+
+  useScrollLock(isOpen && lockScroll);
+  useEscapeKeyClose({ closeOnEscape, isOpen, onClose: handleClose });
+
+  return {
+    isOpen,
+    handleOpen,
+    handleClose,
+  };
+};
+
+export default usePopup;

--- a/apps/web/src/hooks/useScrollLock.ts
+++ b/apps/web/src/hooks/useScrollLock.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+const useScrollLock = (isActive: boolean) => {
+  useEffect(() => {
+    if (!isActive) return;
+
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+
+    document.body.classList.add('scroll-lock');
+
+    return () => {
+      document.body.classList.remove('scroll-lock');
+      document.body.style.paddingRight = '';
+    };
+  }, [isActive]);
+};
+
+export default useScrollLock;

--- a/apps/web/src/theme/emotion.d.ts
+++ b/apps/web/src/theme/emotion.d.ts
@@ -2,11 +2,13 @@ import '@emotion/react';
 import { typography } from './typography';
 import { colors } from './colors';
 import { effects } from './effects';
+import { zIndex } from './zIndex';
 
 declare module '@emotion/react' {
   export interface Theme {
     colors: typeof colors;
     typography: typeof typography;
     effects: typeof effects;
+    zIndex: typeof zIndex;
   }
 }

--- a/apps/web/src/theme/index.ts
+++ b/apps/web/src/theme/index.ts
@@ -1,3 +1,4 @@
+import { zIndex } from './zIndex';
 import { effects } from './effects';
 import { colors } from './colors';
 import { typography } from './typography';
@@ -7,4 +8,5 @@ export const theme: Theme = {
   typography,
   colors,
   effects,
+  zIndex,
 };

--- a/apps/web/src/theme/zIndex.ts
+++ b/apps/web/src/theme/zIndex.ts
@@ -1,0 +1,5 @@
+export const zIndex = {
+  popupRoot: 1000,
+  overlay: 1100,
+  modal: 1200,
+} as const;


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #18 

## 🛠 2. 작업 내용

### 팝업 컴포넌트
- 공통 레이아웃(PopupRoot/PopupLayer/Backdrop)과 스타일 추가
- Modal/Overlay 컴포넌트 및 스타일 추가, Content/Footer 슬롯 구성
- 팝업 훅(usePopup) 및 부가 훅(useEscapeKeyClose/useScrollLock) 추가

### 테마 zIndex 추가

### FloatingButton backdrop-filter 적용 방식 수정

## 📌 3. 참고 사항

- PopupRoot는 `createPortal`로 `document.body`에 렌더링되며, Backdrop/Layer를 포함한 공통 레이아웃을 제공합니다.
- PopupLayer는 중앙 정렬된 컨테이너로, 실제 콘텐츠(Modal/Overlay Content)가 들어가는 영역입니다.
- Modal/Overlay 모두 `isOpen`이 `false`면 `null`을 반환해 렌더링을 막습니다.
- `usePopup`은 `handleOpen/handleClose`를 제공하고, 옵션으로 Escape 닫기/스크롤 잠금 동작을 제어합니다.

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ] PopupRoot/Backdrop/Layer 구조에 대한 피드백

## 🧪 5. 테스트

[스토리북 배포](https://6957d120c0181ab689c1a245-iwkbzaeyib.chromatic.com/?path=/docs/components-popup-overlay--docs)

## 사용 예시

**Popup 구조**
- `PopupRoot` (Portal, 최상위 fixed 레이어)
  - `Backdrop` (배경 클릭 시 닫기)
  - `PopupLayer` (중앙 정렬, 콘텐츠 래퍼)

**Modal 사용**
```tsx
const { isOpen, handleOpen, handleClose } = usePopup();

<Button text="모달 열기" onClick={handleOpen} />
<Modal isOpen={isOpen} onClose={handleClose}>
  <Modal.Content>
    <h2>Modal Example</h2>
    <Modal.Footer>
      <TextButton text="취소" onClick={handleClose} />
      <TextButton text="확인" onClick={handleClose} />
    </Modal.Footer>
  </Modal.Content>
</Modal>
```

**Overlay 사용**
```tsx
const { isOpen, handleOpen, handleClose } = usePopup({
  closeOnEscape: false,
  lockScroll: false,
});

<Button text="오버레이 열기" onClick={handleOpen} />
<Overlay isOpen={isOpen} onClose={handleClose}>
  <Overlay.Content>
    <h2>Overlay Example</h2>
    <Overlay.Footer>
      <TextButton text="닫기" onClick={handleClose} />
      <TextButton text="확인" onClick={handleClose} />
    </Overlay.Footer>
  </Overlay.Content>
</Overlay>
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모달/오버레이 팝업 컴포넌트 추가(Backdrop, Layer, Root 포함) — Content·Footer 서브컴포넌트 제공, 포탈 기반 렌더링 지원.
  * 팝업 관련 훅 추가 — 열기/닫기 관리, Escape로 닫기, 스크롤 잠금 지원.
  * 테마 z-index 값과 모달 포탈 대상 DOM 추가.

* **버그 수정**
  * 버튼 컴포넌트들이 추가 HTML 속성(aria-, data-, 이벤트 등)을 전달하도록 개선.

* **스타일**
  * 백드롭 블러 스타일 표현 방식 수정.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->