### PR TITLE
feat: add photo grid component

### DIFF
--- a/apps/web/src/components/photoGridContainer/PhotoGridContainer.stories.tsx
+++ b/apps/web/src/components/photoGridContainer/PhotoGridContainer.stories.tsx
@@ -1,0 +1,53 @@
+import PhotoGridContainer from '@/components/photoGridContainer/PhotoGridContainer';
+import PhotoGridItem from '@/components/photoGridItem/PhotoGridItem';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PhotoGridContainer> = {
+  title: 'Components/PhotoGridContainer',
+  component: PhotoGridContainer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PhotoGridContainer>;
+
+export const Default: Story = {
+  render: () => (
+    <PhotoGridContainer>
+      {Array.from({ length: 9 }).map((_, i) => (
+        <PhotoGridItem
+          key={i}
+          src={`https://picsum.photos/118/157?random=${i}`}
+          date={`2024-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`}
+          alt={`Photo ${i + 1}`}
+        />
+      ))}
+    </PhotoGridContainer>
+  ),
+};
+
+export const WithBrokenImages: Story = {
+  render: () => (
+    <PhotoGridContainer>
+      <PhotoGridItem
+        src="https://picsum.photos/118/157?random=1"
+        date="2024-01-01T00:00:00.000Z"
+      />
+      <PhotoGridItem src="" date="2024-01-02T00:00:00.000Z" alt="Broken" />
+      <PhotoGridItem
+        src="https://picsum.photos/118/157?random=3"
+        date="2024-01-03T00:00:00.000Z"
+      />
+      <PhotoGridItem src="" date="2024-01-04T00:00:00.000Z" alt="No image" />
+      <PhotoGridItem
+        src="https://picsum.photos/118/157?random=5"
+        date="2024-01-05T00:00:00.000Z"
+      />
+      <PhotoGridItem
+        src="https://picsum.photos/118/157?random=6"
+        date="2024-01-06T00:00:00.000Z"
+      />
+    </PhotoGridContainer>
+  ),
+};

--- a/apps/web/src/components/photoGridContainer/PhotoGridContainer.stories.tsx
+++ b/apps/web/src/components/photoGridContainer/PhotoGridContainer.stories.tsx
@@ -2,6 +2,8 @@ import PhotoGridContainer from '@/components/photoGridContainer/PhotoGridContain
 import PhotoGridItem from '@/components/photoGridItem/PhotoGridItem';
 import type { Meta, StoryObj } from '@storybook/react';
 
+const handleClick = () => {};
+
 const meta: Meta<typeof PhotoGridContainer> = {
   title: 'Components/PhotoGridContainer',
   component: PhotoGridContainer,
@@ -21,6 +23,7 @@ export const Default: Story = {
           src={`https://picsum.photos/118/157?random=${i}`}
           date={`2024-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`}
           alt={`Photo ${i + 1}`}
+          onClick={handleClick}
         />
       ))}
     </PhotoGridContainer>
@@ -33,20 +36,34 @@ export const WithBrokenImages: Story = {
       <PhotoGridItem
         src="https://picsum.photos/118/157?random=1"
         date="2024-01-01T00:00:00.000Z"
+        onClick={handleClick}
       />
-      <PhotoGridItem src="" date="2024-01-02T00:00:00.000Z" alt="Broken" />
+      <PhotoGridItem
+        src=""
+        date="2024-01-02T00:00:00.000Z"
+        alt="Broken"
+        onClick={handleClick}
+      />
       <PhotoGridItem
         src="https://picsum.photos/118/157?random=3"
         date="2024-01-03T00:00:00.000Z"
+        onClick={handleClick}
       />
-      <PhotoGridItem src="" date="2024-01-04T00:00:00.000Z" alt="No image" />
+      <PhotoGridItem
+        src=""
+        date="2024-01-04T00:00:00.000Z"
+        alt="No image"
+        onClick={handleClick}
+      />
       <PhotoGridItem
         src="https://picsum.photos/118/157?random=5"
         date="2024-01-05T00:00:00.000Z"
+        onClick={handleClick}
       />
       <PhotoGridItem
         src="https://picsum.photos/118/157?random=6"
         date="2024-01-06T00:00:00.000Z"
+        onClick={handleClick}
       />
     </PhotoGridContainer>
   ),

--- a/apps/web/src/components/photoGridContainer/PhotoGridContainer.styles.ts
+++ b/apps/web/src/components/photoGridContainer/PhotoGridContainer.styles.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2px;
+`;

--- a/apps/web/src/components/photoGridContainer/PhotoGridContainer.tsx
+++ b/apps/web/src/components/photoGridContainer/PhotoGridContainer.tsx
@@ -1,0 +1,8 @@
+import { PropsWithChildren } from 'react';
+import * as S from './PhotoGridContainer.styles';
+
+const PhotoGridContainer = ({ children }: PropsWithChildren) => {
+  return <S.Container>{children}</S.Container>;
+};
+
+export default PhotoGridContainer;

--- a/apps/web/src/components/photoGridItem/PhotoGridItem.stories.tsx
+++ b/apps/web/src/components/photoGridItem/PhotoGridItem.stories.tsx
@@ -1,0 +1,35 @@
+import PhotoGridItem from '@/components/photoGridItem/PhotoGridItem';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof PhotoGridItem> = {
+  title: 'Components/PhotoGridItem',
+  component: PhotoGridItem,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PhotoGridItem>;
+
+export const Default: Story = {
+  args: {
+    src: 'https://picsum.photos/118/157',
+    date: '2024-01-15T00:00:00.000Z',
+    alt: 'Sample photo',
+  },
+};
+
+export const WithoutAlt: Story = {
+  args: {
+    src: 'https://picsum.photos/118/157',
+    date: '2024-12-25T00:00:00.000Z',
+  },
+};
+
+export const BrokenImage: Story = {
+  args: {
+    src: '',
+    date: '2024-03-08T00:00:00.000Z',
+    alt: 'Broken image',
+  },
+};

--- a/apps/web/src/components/photoGridItem/PhotoGridItem.styles.ts
+++ b/apps/web/src/components/photoGridItem/PhotoGridItem.styles.ts
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 
 export const Container = styled.div`
   position: relative;
-  width: 118px;
-  height: 157px;
+  width: 100%;
+  aspect-ratio: 118 / 157;
 `;
 
 export const Photo = styled.img`

--- a/apps/web/src/components/photoGridItem/PhotoGridItem.styles.ts
+++ b/apps/web/src/components/photoGridItem/PhotoGridItem.styles.ts
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  position: relative;
+  width: 118px;
+  height: 157px;
+`;
+
+export const Photo = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background-color: ${({ theme }) => theme.colors.blueWhite.bg8};
+`;
+
+export const DateBadge = styled.div`
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 41px;
+  height: 41px;
+  border-radius: 6px;
+  background-color: ${({ theme }) => theme.colors.gray[1000]};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.gray[0]};
+`;
+
+export const Day = styled.span`
+  ${({ theme }) => theme.typography.heading18Bold}
+  line-height: 1;
+`;
+
+export const Month = styled.span`
+  ${({ theme }) => theme.typography.caption11Regular}
+  line-height: 1;
+`;
+
+export const Fallback = styled.div`
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.blueWhite.bg8};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  ${({ theme }) => theme.typography.caption12Regular}
+  text-align: center;
+  padding: 8px;
+  word-break: keep-all;
+`;

--- a/apps/web/src/components/photoGridItem/PhotoGridItem.styles.ts
+++ b/apps/web/src/components/photoGridItem/PhotoGridItem.styles.ts
@@ -1,9 +1,22 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.div`
+export const Container = styled.button`
   position: relative;
   width: 100%;
   aspect-ratio: 118 / 157;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+  background: transparent;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:active {
+    opacity: 0.8;
+  }
 `;
 
 export const Photo = styled.img`

--- a/apps/web/src/components/photoGridItem/PhotoGridItem.tsx
+++ b/apps/web/src/components/photoGridItem/PhotoGridItem.tsx
@@ -6,30 +6,34 @@ interface PhotoGridItemProps {
   alt?: string;
   /** 이미지 src URL */
   src: string;
-  /** ISO 8601 형식의 날짜 문자열 */
-  date: string;
+  /** ISO 8601 형식의 날짜 문자열 (있으면 배지 표시) */
+  date?: string;
+  /** 클릭 이벤트 */
+  onClick: () => void;
 }
 
-const PhotoGridItem = ({ alt = '', src, date }: PhotoGridItemProps) => {
+const PhotoGridItem = ({ alt = '', src, date, onClick }: PhotoGridItemProps) => {
   const [hasError, setHasError] = useState(false);
 
-  const dateObj = new Date(date);
-  const day = dateObj.getDate();
-  const month = dateObj.getMonth() + 1;
+  const dateObj = date ? new Date(date) : null;
+  const day = dateObj?.getDate();
+  const month = dateObj ? dateObj.getMonth() + 1 : null;
 
   const showFallback = hasError || !src;
 
   return (
-    <S.Container>
+    <S.Container type="button" onClick={onClick}>
       {showFallback ? (
         <S.Fallback>{alt}</S.Fallback>
       ) : (
         <S.Photo src={src} alt={alt} onError={() => setHasError(true)} />
       )}
-      <S.DateBadge>
-        <S.Day>{day}</S.Day>
-        <S.Month>{month}월</S.Month>
-      </S.DateBadge>
+      {dateObj && (
+        <S.DateBadge>
+          <S.Day>{day}</S.Day>
+          <S.Month>{month}월</S.Month>
+        </S.DateBadge>
+      )}
     </S.Container>
   );
 };

--- a/apps/web/src/components/photoGridItem/PhotoGridItem.tsx
+++ b/apps/web/src/components/photoGridItem/PhotoGridItem.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import * as S from './PhotoGridItem.styles';
+
+interface PhotoGridItemProps {
+  /** 이미지 alt 텍스트 */
+  alt?: string;
+  /** 이미지 src URL */
+  src: string;
+  /** ISO 8601 형식의 날짜 문자열 */
+  date: string;
+}
+
+const PhotoGridItem = ({ alt = '', src, date }: PhotoGridItemProps) => {
+  const [hasError, setHasError] = useState(false);
+
+  const dateObj = new Date(date);
+  const day = dateObj.getDate();
+  const month = dateObj.getMonth() + 1;
+
+  const showFallback = hasError || !src;
+
+  return (
+    <S.Container>
+      {showFallback ? (
+        <S.Fallback>{alt}</S.Fallback>
+      ) : (
+        <S.Photo src={src} alt={alt} onError={() => setHasError(true)} />
+      )}
+      <S.DateBadge>
+        <S.Day>{day}</S.Day>
+        <S.Month>{month}월</S.Month>
+      </S.DateBadge>
+    </S.Container>
+  );
+};
+
+export default PhotoGridItem;


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #22 

## 🛠 2. 작업 내용

- PhotoGridItem
- PhotoGridContainer

## 📌 3. 참고 사항

[피그마](https://www.figma.com/design/jCHkG2pc6SC7dwyO2gdIlI/-Lokit--V1-Launch?node-id=1996-13358&m=dev)

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ] 추후 반응형을 고려해 fixed size보다는 aspect-ratio로 작성됐습니다.

## 🧪 5. 테스트

[로컬 스토리북](http://localhost:6006/?path=/docs/components-photogridcontainer--docs&globals=backgrounds.value:dark;backgrounds.grid:!undefined)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진을 3열 격자로 표시하는 PhotoGrid 컨테이너 추가
  * 날짜 배지, 대체 텍스트, 클릭 동작, 로드 실패 시 폴백을 포함한 개별 사진 항목 컴포넌트 추가
  * 스타일 기반 레이아웃과 폴백 UI로 손상/빈 이미지 처리 개선

* **Tests**
  * PhotoGridContainer 및 PhotoGridItem에 대한 Storybook 스토리 추가(기본, 대체텍스트 없음, 손상 이미지 시나리오 포함)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->