### PR TITLE
feat: 지도 미리보기 기능 추가

### DIFF
--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { motion } from 'framer-motion';
+import { useRouter } from 'next/navigation';
 import { useGetPhotoDetail } from '@repo/api-client';
 import { PhotoAddHeader } from '@/components/header';
 import * as HeaderStyles from '@/components/header/photoAdd/PhotoAddHeader.styles';
+import { ROUTES } from '@/constants';
 import MemoModal from '../../add/note/_components/MemoModal';
 import AlbumSelectOverlay from '../../add/note/_components/AlbumSelectOverlay';
 import LocationSelectOverlay from '../../add/note/_components/LocationSelectOverlay';
@@ -36,6 +38,7 @@ export default function PhotoEditOverlay({
   onSave,
   isSaving = false,
 }: PhotoEditOverlayProps) {
+  const router = useRouter();
   const { data: photoDetail, isLoading } = useGetPhotoDetail(photoId);
   const {
     memo,
@@ -74,6 +77,25 @@ export default function PhotoEditOverlay({
     closeModal: handleLocationModalClose,
     submitLocation: handleLocationSubmit,
   } = useLocationModal();
+
+  const handleMapPreview = () => {
+    if (!photoDetail || !selectedLocation) return;
+
+    const latitude = selectedLocation.latitude;
+    const longitude = selectedLocation.longitude;
+
+    if (latitude && longitude) {
+      sessionStorage.setItem(
+        'mapPreviewState',
+        JSON.stringify({
+          latitude,
+          longitude,
+          photoUrl: photoDetail.url || '',
+        })
+      );
+      router.push(ROUTES.PHOTO.PREVIEW);
+    }
+  };
 
   const handleSave = () => {
     const latitude = selectedLocation?.latitude;
@@ -201,7 +223,11 @@ export default function PhotoEditOverlay({
 
         <S.BottomContainer>
           <S.ActionButtons>
-            <S.MapPreviewButton type="button">
+            <S.MapPreviewButton
+              type="button"
+              onClick={handleMapPreview}
+              disabled={!selectedLocation}
+            >
               <S.MapIcon>
                 <MapPinIcon width={16} height={17} />
               </S.MapIcon>

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
@@ -119,8 +119,22 @@ export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
   };
 
   const handleMapPreview = () => {
-    // TODO: 지도뷰 미리보기 구현
-    console.log('Open map preview');
+    if (!selectedPhoto || !hasLocation) return;
+
+    const latitude = selectedLocation?.latitude || selectedPhoto.location?.latitude;
+    const longitude = selectedLocation?.longitude || selectedPhoto.location?.longitude;
+
+    if (latitude && longitude) {
+      sessionStorage.setItem(
+        'mapPreviewState',
+        JSON.stringify({
+          latitude,
+          longitude,
+          photoUrl: selectedPhoto.uri,
+        })
+      );
+      router.push(ROUTES.PHOTO.PREVIEW);
+    }
   };
 
   if (!selectedPhoto) {

--- a/apps/web/src/app/photo/preview/page.styles.ts
+++ b/apps/web/src/app/photo/preview/page.styles.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  position: relative;
+`;

--- a/apps/web/src/app/photo/preview/page.tsx
+++ b/apps/web/src/app/photo/preview/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import MapPreview from '@/components/map/MapPreview';
+
+interface MapPreviewState {
+  latitude: number;
+  longitude: number;
+  photoUrl: string;
+}
+
+export default function PhotoPreviewPage() {
+  const router = useRouter();
+  const [state, setState] = useState<MapPreviewState | null>(null);
+
+  useEffect(() => {
+    const savedState = sessionStorage.getItem('mapPreviewState');
+    if (savedState) {
+      try {
+        const parsedState = JSON.parse(savedState) as MapPreviewState;
+        if (parsedState?.latitude && parsedState?.longitude) {
+          setState(parsedState);
+          // 사용 후 삭제
+          sessionStorage.removeItem('mapPreviewState');
+        }
+      } catch (error) {
+        console.error('Failed to parse mapPreviewState:', error);
+      }
+    }
+  }, []);
+
+  const handleClose = () => {
+    router.back();
+  };
+
+  if (!state) {
+    return null;
+  }
+
+  return (
+    <MapPreview
+      latitude={state.latitude}
+      longitude={state.longitude}
+      photoUrl={state.photoUrl}
+      onClose={handleClose}
+    />
+  );
+}

--- a/apps/web/src/components/map/MapPreview.styles.ts
+++ b/apps/web/src/components/map/MapPreview.styles.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+`;
+
+export const MapContainer = styled.div`
+  flex: 1;
+  position: relative;
+  width: 100%;
+`;

--- a/apps/web/src/components/map/MapPreview.tsx
+++ b/apps/web/src/components/map/MapPreview.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import MapView from './MapView';
+import BottomSheet from '../bottomSheet/BottomSheet';
+import MenuHeader from '../header/menu/MenuHeader';
+import { LocationState, MapPin } from '@/types/map.type';
+import { SHEET_CONTEXT_TYPE, SheetContext } from '../bottomSheet/constants';
+import * as S from './MapPreview.styles';
+
+const DEFAULT_ZOOM = 17;
+
+interface MapPreviewProps {
+  latitude: number;
+  longitude: number;
+  photoUrl: string;
+  onClose: () => void;
+}
+
+export default function MapPreview({
+  latitude,
+  longitude,
+  photoUrl,
+  onClose,
+}: MapPreviewProps) {
+  const [context, setContext] = useState<SheetContext>({
+    type: SHEET_CONTEXT_TYPE.ALBUM_LIST,
+  });
+
+  // 사진 위치를 지도 핀으로 변환
+  const mapPin: MapPin = {
+    id: 1,
+    albumId: 0,
+    latitude,
+    longitude,
+    imageUrl: photoUrl,
+    imageCount: 1,
+  };
+
+  const locationState: LocationState = {
+    latitude,
+    longitude,
+    zoom: DEFAULT_ZOOM,
+  };
+
+  return (
+    <S.Container>
+      <MenuHeader title="지도뷰 미리보기" onClickBack={onClose}>
+        <MenuHeader.Menu>
+          <MenuHeader.Item>공유</MenuHeader.Item>
+          <MenuHeader.Item>저장</MenuHeader.Item>
+        </MenuHeader.Menu>
+      </MenuHeader>
+
+      <S.MapContainer>
+        <MapView locationState={locationState} pins={[mapPin]} selectedAlbumId={null} />
+      </S.MapContainer>
+
+      <BottomSheet
+        context={context}
+        albums={[{ id: 1, title: '전체보기', photoList: [], photoCount: 0 }]}
+        albumDetailById={{}}
+        onChangeContext={setContext}
+        onSelectAlbum={() => {}}
+      />
+    </S.Container>
+  );
+}

--- a/apps/web/src/components/map/MapPreview.tsx
+++ b/apps/web/src/components/map/MapPreview.tsx
@@ -24,7 +24,7 @@ export default function MapPreview({
   onClose,
 }: MapPreviewProps) {
   const [context, setContext] = useState<SheetContext>({
-    type: SHEET_CONTEXT_TYPE.ALBUM_LIST,
+    type: SHEET_CONTEXT_TYPE.HOME,
   });
 
   // 사진 위치를 지도 핀으로 변환

--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -7,5 +7,6 @@ export const ROUTES = {
     },
     VIEW: (photoId: number, albumId?: number) =>
       albumId ? `/photo/${photoId}?albumId=${albumId}` : `/photo/${photoId}`,
+    PREVIEW: '/photo/preview',
   },
 } as const;


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #37 

## 🛠 2. 작업 내용

- 사진 수정, 메모 모달에 지도 미리보기를 추가하였습니다.

https://github.com/user-attachments/assets/c7da672d-3b9d-494a-91ff-1dfff5119111


## 📌 3. 참고 사항

- 지도 미리보기 시, `경도`, `위도`, `이미지 경로`가 필요합니다.
- 이 세가지 전달 방법에 대해서 1.urlParams 2.history 3. session 4. context 주입
을 생각해보았으나, 1은 이미지 경로와 같은 정보가 url에 노출된다는 점, 2의 경우 route.push() 후 history가 유지되지 않는다는 문제, 4의 경우에는 주요기능이 아님에도 context를 주입하는 것이 오버헤드가 크다고 판다하여, session 방식으로 관리되도록 하였습니다.
- 세션 스토리지에 있는 값을 사용한 후, 제거하도록 구현하였습니다.

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ]

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1.
2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사진에 대해 지도 미리보기 기능이 추가되었습니다. 사진에서 위치를 선택하면 미리보기 화면으로 이동해 해당 위치와 사진을 지도에서 확인할 수 있습니다.
  * 미리보기 전용 화면과 관련 UI(헤더, 지도 뷰, 하단 시트)가 제공되어 위치 콘텍스트를 확인하고 화면을 닫아 돌아올 수 있습니다.
  * 미리보기 접근 버튼은 위치가 없을 때 비활성화됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->