### PR TITLE
feat: map 정책 수정

### DIFF
--- a/apps/web/src/components/map/MapView.tsx
+++ b/apps/web/src/components/map/MapView.tsx
@@ -71,8 +71,8 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(
             zoom: locationState.zoom,
           }}
           maxBounds={[
-            [124.5, 33.1],
-            [131.9, 43.0],
+            [124.5, 31.1],
+            [131.9, 38.8],
           ]}
           onMove={(evt) => {
             if (onViewStateChange) {

--- a/apps/web/src/components/map/MapView.tsx
+++ b/apps/web/src/components/map/MapView.tsx
@@ -70,6 +70,10 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(
             longitude: locationState.longitude,
             zoom: locationState.zoom,
           }}
+          maxBounds={[
+            [124.5, 33.1],
+            [131.9, 43.0],
+          ]}
           onMove={(evt) => {
             if (onViewStateChange) {
               onViewStateChange({

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -70,7 +70,7 @@ export const useMapMe = ({
       isCluster: true,
     }));
 
-    return roundedZoom >= 16 ? photoPins : clusterPins;
+    return roundedZoom >= 17 ? photoPins : clusterPins;
   }, [response.data, roundedZoom]);
 
   return {

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -70,7 +70,7 @@ export const useMapMe = ({
       isCluster: true,
     }));
 
-    return roundedZoom >= 15 ? photoPins : clusterPins;
+    return roundedZoom >= 16 ? photoPins : clusterPins;
   }, [response.data, roundedZoom]);
 
   return {


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #91 

## 🛠 2. 작업 내용

#### 클러스터 줌 레벨을 15 -> 16으로 조정
#### 줌 아웃시 대한민국 기준 maxBound 추가

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->


## 🧪 5. 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 지도 드래그가 특정 경계([[124.5, 31.1], [131.9, 38.8]]) 내로 제한됩니다.
  * 지도 핀 표시 기준의 줌 경계가 조정되어(기존보다 높은 줌에서 사진 핀이 표시됨) 핀 표시가 더 적절해집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->