### PR TITLE
fix: qa

### DIFF
--- a/apps/web/src/app/_components/MapRoute.tsx
+++ b/apps/web/src/app/_components/MapRoute.tsx
@@ -208,10 +208,6 @@ export default function MapRoute() {
         isOpen={isLocationDeniedModalOpen}
         onClose={handleCloseLocationDeniedModal}
       />
-      <LocationPermissionModal
-        isOpen={isLocationDeniedModalOpen}
-        onClose={handleCloseLocationDeniedModal}
-      />
     </S.Wrapper>
   );
 }

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
@@ -50,7 +50,7 @@ export default function PhotoEditOverlay({
     openModal: handleAddMemo,
     closeModal: handleMemoModalClose,
     submitMemo: handleMemoSubmit,
-  } = useMemoModal(photoDetail?.description || '');
+  } = useMemoModal({ initialMemo: photoDetail?.description || '' });
 
   const {
     selectedAlbum,
@@ -79,7 +79,7 @@ export default function PhotoEditOverlay({
     openModal: handleAddLocation,
     closeModal: handleLocationModalClose,
     submitLocation: handleLocationSubmit,
-  } = useLocationModal();
+  } = useLocationModal({ useLocalState: true });
 
   // photoDetail이 로드되면 기존 좌표값으로 초기화
   useEffect(() => {

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
@@ -7,6 +7,8 @@ import { useGetPhotoDetail } from '@repo/api-client';
 import { PhotoAddHeader } from '@/components/header';
 import * as HeaderStyles from '@/components/header/photoAdd/PhotoAddHeader.styles';
 import { ROUTES } from '@/constants';
+import { usePhotoContext } from '../../_contexts/PhotoContext';
+import { STATE_SOURCE } from '../../_constants/stateSource';
 import MemoModal from '../../add/note/_components/MemoModal';
 import AlbumSelectOverlay from '../../add/note/_components/AlbumSelectOverlay';
 import LocationSelectOverlay from '../../add/note/_components/LocationSelectOverlay';
@@ -41,7 +43,28 @@ export default function PhotoEditOverlay({
   isSaving = false,
 }: PhotoEditOverlayProps) {
   const router = useRouter();
+  const { initPhotoEditState, isEditStateInitialized } = usePhotoContext();
   const { data: photoDetail, isLoading } = useGetPhotoDetail(photoId);
+
+  // photoDetail이 로드되면 photoEditState 초기화 (최초 1회만)
+  // 지도뷰 미리보기에서 복귀 시에는 이미 초기화되어 있으므로 스킵
+  useEffect(() => {
+    if (photoDetail && !isEditStateInitialized) {
+      initPhotoEditState({
+        memo: photoDetail.description || '',
+        selectedAlbum: null, // API에서 albumId를 제공하지 않아서 초기 선택 불가
+        selectedLocation:
+          photoDetail.latitude != null && photoDetail.longitude != null
+            ? {
+                latitude: photoDetail.latitude,
+                longitude: photoDetail.longitude,
+                address: photoDetail.address,
+              }
+            : null,
+      });
+    }
+  }, [photoDetail, isEditStateInitialized, initPhotoEditState]);
+
   const {
     memo,
     tempMemo,
@@ -50,7 +73,7 @@ export default function PhotoEditOverlay({
     openModal: handleAddMemo,
     closeModal: handleMemoModalClose,
     submitMemo: handleMemoSubmit,
-  } = useMemoModal({ initialMemo: photoDetail?.description || '' });
+  } = useMemoModal({ stateSource: STATE_SOURCE.EDIT });
 
   const {
     selectedAlbum,
@@ -64,11 +87,10 @@ export default function PhotoEditOverlay({
     openModal: handleAlbumSelect,
     closeModal: handleAlbumModalClose,
     submitAlbum: handleAlbumSubmit,
-  } = useAlbumModal();
+  } = useAlbumModal({ stateSource: STATE_SOURCE.EDIT });
 
   const {
     selectedLocation,
-    setSelectedLocation,
     tempSelectedLocationId,
     setTempSelectedLocationId,
     searchQuery: locationSearchQuery,
@@ -79,22 +101,7 @@ export default function PhotoEditOverlay({
     openModal: handleAddLocation,
     closeModal: handleLocationModalClose,
     submitLocation: handleLocationSubmit,
-  } = useLocationModal({ useLocalState: true });
-
-  // photoDetail이 로드되면 기존 좌표값으로 초기화
-  useEffect(() => {
-    if (
-      photoDetail?.latitude != null &&
-      photoDetail?.longitude != null &&
-      !selectedLocation
-    ) {
-      setSelectedLocation({
-        latitude: photoDetail.latitude,
-        longitude: photoDetail.longitude,
-        address: photoDetail.address,
-      });
-    }
-  }, [photoDetail, selectedLocation, setSelectedLocation]);
+  } = useLocationModal({ stateSource: STATE_SOURCE.EDIT });
 
   const handleMapPreview = () => {
     if (!photoDetail || !selectedLocation) return;

--- a/apps/web/src/app/photo/[photoId]/_hooks/usePhotoEdit.ts
+++ b/apps/web/src/app/photo/[photoId]/_hooks/usePhotoEdit.ts
@@ -1,7 +1,7 @@
-import { useState } from 'react';
 import { useUpdate, getGetPhotoDetailQueryKey } from '@repo/api-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/components/toast/ToastProvider';
+import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
 import type { PhotoLocation } from '@/app/photo/add/_types/photo';
 
 interface EditData {
@@ -12,10 +12,12 @@ interface EditData {
 }
 
 const usePhotoEdit = () => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [editingPhotoId, setEditingPhotoId] = useState<number | null>(null);
+  const { editingPhotoId, setEditingPhotoId, initPhotoEditState } = usePhotoContext();
   const queryClient = useQueryClient();
   const { showToast } = useToast();
+
+  // editingPhotoId가 있으면 수정 중인 상태
+  const isEditing = editingPhotoId !== null;
 
   const { mutate: updatePhoto, isPending: isSaving } = useUpdate({
     mutation: {
@@ -24,8 +26,8 @@ const usePhotoEdit = () => {
           queryKey: getGetPhotoDetailQueryKey(variables.id),
         });
         showToast('기록이 수정되었어요');
-        setIsEditing(false);
         setEditingPhotoId(null);
+        initPhotoEditState({});
       },
       onError: (error) => {
         console.error('사진 수정 실패:', error);
@@ -36,12 +38,11 @@ const usePhotoEdit = () => {
 
   const openEditOverlay = (photoId: number) => {
     setEditingPhotoId(photoId);
-    setIsEditing(true);
   };
 
   const closeEditOverlay = () => {
-    setIsEditing(false);
     setEditingPhotoId(null);
+    initPhotoEditState({});
   };
 
   const saveEdit = (data: EditData) => {

--- a/apps/web/src/app/photo/_constants/stateSource.ts
+++ b/apps/web/src/app/photo/_constants/stateSource.ts
@@ -1,0 +1,7 @@
+/** 상태 소스 타입: 사진 추가(note) 또는 사진 수정(edit) */
+export const STATE_SOURCE = {
+  NOTE: 'note',
+  EDIT: 'edit',
+} as const;
+
+export type StateSource = (typeof STATE_SOURCE)[keyof typeof STATE_SOURCE];

--- a/apps/web/src/app/photo/_contexts/PhotoContext.tsx
+++ b/apps/web/src/app/photo/_contexts/PhotoContext.tsx
@@ -36,6 +36,10 @@ interface PhotoContextValue {
   selectedPhotoRect: PhotoRect | null;
   /** 선택한 사진 위치 설정 - UI 상태 */
   setSelectedPhotoRect: (rect: PhotoRect | null) => void;
+  /** 사진 추가 시 기본으로 선택할 앨범 ID */
+  initialAlbumId: number | null;
+  /** 기본 앨범 ID 설정 */
+  setInitialAlbumId: (albumId: number | null) => void;
 }
 
 const PhotoContext = createContext<PhotoContextValue | null>(null);
@@ -44,6 +48,7 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
   const [photos, setPhotos] = useState<SelectedPhoto[]>([]);
   const [selectedPhoto, setSelectedPhoto] = useState<SelectedPhoto | null>(null);
   const [selectedPhotoRect, setSelectedPhotoRect] = useState<PhotoRect | null>(null);
+  const [initialAlbumId, setInitialAlbumId] = useState<number | null>(null);
 
   const addPhotos = useCallback((newPhotos: SelectedPhoto[]) => {
     setPhotos((prev) => [...prev, ...newPhotos]);
@@ -57,8 +62,10 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
       setSelectedPhoto,
       selectedPhotoRect,
       setSelectedPhotoRect,
+      initialAlbumId,
+      setInitialAlbumId,
     }),
-    [photos, addPhotos, selectedPhoto, selectedPhotoRect],
+    [photos, addPhotos, selectedPhoto, selectedPhotoRect, initialAlbumId],
   );
 
   return <PhotoContext.Provider value={value}>{children}</PhotoContext.Provider>;

--- a/apps/web/src/app/photo/_contexts/PhotoContext.tsx
+++ b/apps/web/src/app/photo/_contexts/PhotoContext.tsx
@@ -57,8 +57,20 @@ interface PhotoContextValue {
   photoNoteState: PhotoNoteState;
   /** 사진 정보 기입 상태 업데이트 */
   updatePhotoNoteState: (state: Partial<PhotoNoteState>) => void;
-  /** 사진 정보 기입 상태 초기화 */
-  resetPhotoNoteState: () => void;
+  /** 사진 정보 기입 상태 초기화 (사진의 위치 정보가 있으면 그걸로 초기화) */
+  resetPhotoNoteState: (photo?: SelectedPhoto) => void;
+  /** 사진 수정 화면의 상태 */
+  photoEditState: PhotoNoteState;
+  /** 사진 수정 상태 업데이트 */
+  updatePhotoEditState: (state: Partial<PhotoNoteState>) => void;
+  /** 사진 수정 상태 초기화 */
+  initPhotoEditState: (state: Partial<PhotoNoteState>) => void;
+  /** 수정 중인 사진 ID (지도뷰 미리보기 이동 시에도 유지) */
+  editingPhotoId: number | null;
+  /** 수정 중인 사진 ID 설정 */
+  setEditingPhotoId: (photoId: number | null) => void;
+  /** 사진 수정 상태 초기화 완료 여부 */
+  isEditStateInitialized: boolean;
 }
 
 const PhotoContext = createContext<PhotoContextValue | null>(null);
@@ -76,6 +88,10 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
   const [initialAlbumId, setInitialAlbumId] = useState<number | null>(null);
   const [photoNoteState, setPhotoNoteState] =
     useState<PhotoNoteState>(initialPhotoNoteState);
+  const [photoEditState, setPhotoEditState] =
+    useState<PhotoNoteState>(initialPhotoNoteState);
+  const [editingPhotoId, setEditingPhotoId] = useState<number | null>(null);
+  const [isEditStateInitialized, setIsEditStateInitialized] = useState(false);
 
   const addPhotos = useCallback((newPhotos: SelectedPhoto[]) => {
     setPhotos((prev) => [...prev, ...newPhotos]);
@@ -85,8 +101,31 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
     setPhotoNoteState((prev) => ({ ...prev, ...state }));
   }, []);
 
-  const resetPhotoNoteState = useCallback(() => {
-    setPhotoNoteState(initialPhotoNoteState);
+  const resetPhotoNoteState = useCallback((photo?: SelectedPhoto) => {
+    setPhotoNoteState({
+      memo: '',
+      selectedAlbum: null,
+      selectedLocation: photo?.location
+        ? {
+            latitude: photo.location.latitude,
+            longitude: photo.location.longitude,
+          }
+        : null,
+    });
+  }, []);
+
+  const updatePhotoEditState = useCallback((state: Partial<PhotoNoteState>) => {
+    setPhotoEditState((prev) => ({ ...prev, ...state }));
+  }, []);
+
+  const initPhotoEditState = useCallback((state: Partial<PhotoNoteState>) => {
+    setPhotoEditState({ ...initialPhotoNoteState, ...state });
+    // 실제 데이터가 있으면 초기화 완료로 표시, 빈 객체면 리셋
+    const hasData =
+      (state.memo !== undefined && state.memo !== '') ||
+      state.selectedAlbum !== undefined ||
+      state.selectedLocation !== undefined;
+    setIsEditStateInitialized(hasData);
   }, []);
 
   const value = useMemo(
@@ -102,6 +141,12 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
       photoNoteState,
       updatePhotoNoteState,
       resetPhotoNoteState,
+      photoEditState,
+      updatePhotoEditState,
+      initPhotoEditState,
+      editingPhotoId,
+      setEditingPhotoId,
+      isEditStateInitialized,
     }),
     [
       photos,
@@ -112,6 +157,11 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
       photoNoteState,
       updatePhotoNoteState,
       resetPhotoNoteState,
+      photoEditState,
+      updatePhotoEditState,
+      initPhotoEditState,
+      editingPhotoId,
+      isEditStateInitialized,
     ],
   );
 

--- a/apps/web/src/app/photo/_contexts/PhotoContext.tsx
+++ b/apps/web/src/app/photo/_contexts/PhotoContext.tsx
@@ -17,6 +17,19 @@ export interface PhotoRect {
   height: number;
 }
 
+/** 사진 정보 기입 화면의 상태 (지도뷰 미리보기 이동 시에도 유지) */
+export interface PhotoNoteState {
+  memo: string;
+  selectedAlbum: { id: number; title: string } | null;
+  selectedLocation: {
+    latitude: number;
+    longitude: number;
+    address?: string;
+    roadAddress?: string;
+    placeName?: string;
+  } | null;
+}
+
 /**
  * TODO: 기능이 복잡해지면 PhotoAnimationContext로 분리 고려
  * - selectedPhotoRect, setSelectedPhotoRect는 UI 애니메이션 전용 상태
@@ -40,18 +53,40 @@ interface PhotoContextValue {
   initialAlbumId: number | null;
   /** 기본 앨범 ID 설정 */
   setInitialAlbumId: (albumId: number | null) => void;
+  /** 사진 정보 기입 화면의 상태 */
+  photoNoteState: PhotoNoteState;
+  /** 사진 정보 기입 상태 업데이트 */
+  updatePhotoNoteState: (state: Partial<PhotoNoteState>) => void;
+  /** 사진 정보 기입 상태 초기화 */
+  resetPhotoNoteState: () => void;
 }
 
 const PhotoContext = createContext<PhotoContextValue | null>(null);
+
+const initialPhotoNoteState: PhotoNoteState = {
+  memo: '',
+  selectedAlbum: null,
+  selectedLocation: null,
+};
 
 export function PhotoProvider({ children }: { children: ReactNode }) {
   const [photos, setPhotos] = useState<SelectedPhoto[]>([]);
   const [selectedPhoto, setSelectedPhoto] = useState<SelectedPhoto | null>(null);
   const [selectedPhotoRect, setSelectedPhotoRect] = useState<PhotoRect | null>(null);
   const [initialAlbumId, setInitialAlbumId] = useState<number | null>(null);
+  const [photoNoteState, setPhotoNoteState] =
+    useState<PhotoNoteState>(initialPhotoNoteState);
 
   const addPhotos = useCallback((newPhotos: SelectedPhoto[]) => {
     setPhotos((prev) => [...prev, ...newPhotos]);
+  }, []);
+
+  const updatePhotoNoteState = useCallback((state: Partial<PhotoNoteState>) => {
+    setPhotoNoteState((prev) => ({ ...prev, ...state }));
+  }, []);
+
+  const resetPhotoNoteState = useCallback(() => {
+    setPhotoNoteState(initialPhotoNoteState);
   }, []);
 
   const value = useMemo(
@@ -64,8 +99,20 @@ export function PhotoProvider({ children }: { children: ReactNode }) {
       setSelectedPhotoRect,
       initialAlbumId,
       setInitialAlbumId,
+      photoNoteState,
+      updatePhotoNoteState,
+      resetPhotoNoteState,
     }),
-    [photos, addPhotos, selectedPhoto, selectedPhotoRect, initialAlbumId],
+    [
+      photos,
+      addPhotos,
+      selectedPhoto,
+      selectedPhotoRect,
+      initialAlbumId,
+      photoNoteState,
+      updatePhotoNoteState,
+      resetPhotoNoteState,
+    ],
   );
 
   return <PhotoContext.Provider value={value}>{children}</PhotoContext.Provider>;

--- a/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
+++ b/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
@@ -24,11 +24,18 @@ export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectR
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = 'image/*';
-    input.multiple = true;
+    input.multiple = false;
+    input.style.display = 'none';
+    document.body.appendChild(input);
+
+    const cleanup = () => {
+      document.body.removeChild(input);
+    };
 
     input.onchange = async (e) => {
       const files = (e.target as HTMLInputElement).files;
       if (!files || files.length === 0) {
+        cleanup();
         return;
       }
 
@@ -39,7 +46,10 @@ export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectR
 
       optionsRef.current?.onPhotosSelected?.(newPhotos);
       setIsLoading(false);
+      cleanup();
     };
+
+    input.oncancel = cleanup;
 
     input.click();
   }, []);

--- a/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
+++ b/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
@@ -4,6 +4,22 @@ import { useCallback, useRef, useState } from 'react';
 import type { SelectedPhoto } from '../_types/photo';
 import { fileToSelectedPhoto } from '../_utils/fileToSelectedPhoto';
 
+/** XSS 방지를 위해 허용된 이미지 MIME 타입 (SVG 제외) */
+const ALLOWED_IMAGE_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+] as const;
+
+const isAllowedImageType = (file: File): boolean => {
+  return ALLOWED_IMAGE_MIME_TYPES.includes(
+    file.type.toLowerCase() as (typeof ALLOWED_IMAGE_MIME_TYPES)[number],
+  );
+};
+
 interface UsePhotoSelectOptions {
   onPhotosSelected?: (photos: SelectedPhoto[]) => void;
 }
@@ -23,7 +39,7 @@ export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectR
   const selectPhotosFromFile = useCallback(() => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = 'image/*';
+    input.accept = ALLOWED_IMAGE_MIME_TYPES.join(',');
     input.multiple = false;
     input.style.display = 'none';
     document.body.appendChild(input);
@@ -40,13 +56,19 @@ export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectR
       }
 
       setIsLoading(true);
-      const photoPromises = Array.from(files).map((file) => fileToSelectedPhoto(file));
-      const results = await Promise.all(photoPromises);
-      const newPhotos = results.filter((photo): photo is SelectedPhoto => photo !== null);
+      try {
+        const validFiles = Array.from(files).filter(isAllowedImageType);
+        const photoPromises = validFiles.map((file) => fileToSelectedPhoto(file));
+        const results = await Promise.all(photoPromises);
+        const newPhotos = results.filter(
+          (photo): photo is SelectedPhoto => photo !== null,
+        );
 
-      optionsRef.current?.onPhotosSelected?.(newPhotos);
-      setIsLoading(false);
-      cleanup();
+        optionsRef.current?.onPhotosSelected?.(newPhotos);
+      } finally {
+        setIsLoading(false);
+        cleanup();
+      }
     };
 
     input.oncancel = cleanup;

--- a/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
+++ b/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
@@ -12,41 +12,34 @@ interface UsePhotoSelectReturn {
   /** 로딩 중 여부 */
   isLoading: boolean;
   /** 파일 선택으로 사진 추가 */
-  selectPhotosFromFile: () => Promise<void>;
+  selectPhotosFromFile: () => void;
 }
 
 export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectReturn => {
   const [isLoading, setIsLoading] = useState(false);
 
-  const selectPhotosFromFile = useCallback(async () => {
-    return new Promise<void>((resolve) => {
-      const input = document.createElement('input');
-      input.type = 'file';
-      input.accept = 'image/*';
-      input.multiple = true;
+  const selectPhotosFromFile = useCallback(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.multiple = true;
 
-      input.onchange = async (e) => {
-        const files = (e.target as HTMLInputElement).files;
-        if (!files || files.length === 0) {
-          resolve();
-          return;
-        }
+    input.onchange = async (e) => {
+      const files = (e.target as HTMLInputElement).files;
+      if (!files || files.length === 0) {
+        return;
+      }
 
-        setIsLoading(true);
-        const photoPromises = Array.from(files).map((file) => fileToSelectedPhoto(file));
-        const results = await Promise.all(photoPromises);
-        const newPhotos = results.filter(
-          (photo): photo is SelectedPhoto => photo !== null,
-        );
+      setIsLoading(true);
+      const photoPromises = Array.from(files).map((file) => fileToSelectedPhoto(file));
+      const results = await Promise.all(photoPromises);
+      const newPhotos = results.filter((photo): photo is SelectedPhoto => photo !== null);
 
-        options?.onPhotosSelected?.(newPhotos);
-        setIsLoading(false);
-        resolve();
-      };
+      options?.onPhotosSelected?.(newPhotos);
+      setIsLoading(false);
+    };
 
-      input.oncancel = () => resolve();
-      input.click();
-    });
+    input.click();
   }, [options]);
 
   return {

--- a/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
+++ b/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { SelectedPhoto } from '../_types/photo';
 import { fileToSelectedPhoto } from '../_utils/fileToSelectedPhoto';
 
@@ -17,6 +17,8 @@ interface UsePhotoSelectReturn {
 
 export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectReturn => {
   const [isLoading, setIsLoading] = useState(false);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   const selectPhotosFromFile = useCallback(() => {
     const input = document.createElement('input');
@@ -35,12 +37,12 @@ export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectR
       const results = await Promise.all(photoPromises);
       const newPhotos = results.filter((photo): photo is SelectedPhoto => photo !== null);
 
-      options?.onPhotosSelected?.(newPhotos);
+      optionsRef.current?.onPhotosSelected?.(newPhotos);
       setIsLoading(false);
     };
 
     input.click();
-  }, [options]);
+  }, []);
 
   return {
     isLoading,

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
@@ -50,7 +50,7 @@ interface PhotoNoteOverlayProps {
 export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
   const router = useRouter();
   const { showToast } = useToast();
-  const { selectedPhoto, selectedPhotoRect } = usePhotoContext();
+  const { selectedPhoto, selectedPhotoRect, resetPhotoNoteState } = usePhotoContext();
   const {
     memo,
     tempMemo,
@@ -115,6 +115,7 @@ export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
       },
       {
         onSuccess: () => {
+          resetPhotoNoteState();
           showToast('사진이 추가되었습니다');
           if (selectedAlbum) {
             router.replace(ROUTES.ALBUM.DETAIL(selectedAlbum.id));

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
@@ -50,7 +50,7 @@ interface PhotoNoteOverlayProps {
 export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
   const router = useRouter();
   const { showToast } = useToast();
-  const { selectedPhoto, selectedPhotoRect, resetPhotoNoteState } = usePhotoContext();
+  const { selectedPhoto, selectedPhotoRect } = usePhotoContext();
   const {
     memo,
     tempMemo,
@@ -115,7 +115,6 @@ export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
       },
       {
         onSuccess: () => {
-          resetPhotoNoteState();
           showToast('사진이 추가되었습니다');
           if (selectedAlbum) {
             router.replace(ROUTES.ALBUM.DETAIL(selectedAlbum.id));
@@ -158,11 +157,12 @@ export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
   const hasSelectedLocation = !!selectedLocation;
   const hasLocation = hasPhotoLocation || hasSelectedLocation;
 
-  const locationText = selectedLocation
-    ? selectedLocation.placeName ||
-      selectedLocation.roadAddress ||
-      selectedLocation.address
-    : addressData?.placeName || addressData?.address;
+  const locationText =
+    selectedLocation?.placeName ||
+    selectedLocation?.roadAddress ||
+    selectedLocation?.address ||
+    addressData?.placeName ||
+    addressData?.address;
 
   /**
    * scale 애니메이션을 위한 초기값과 transform-origin 계산

--- a/apps/web/src/app/photo/add/note/_hooks/useAlbumModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useAlbumModal.ts
@@ -2,11 +2,30 @@
 
 import { useGetSelectableAlbums, type SelectableAlbum } from '@repo/api-client';
 import { useEffect, useMemo, useState } from 'react';
-import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
+import { usePhotoContext, type PhotoNoteState } from '@/app/photo/_contexts/PhotoContext';
+import { STATE_SOURCE, type StateSource } from '@/app/photo/_constants/stateSource';
 
-const useAlbumModal = () => {
-  const { initialAlbumId, setInitialAlbumId, photoNoteState, updatePhotoNoteState } =
-    usePhotoContext();
+type SelectedAlbum = PhotoNoteState['selectedAlbum'];
+
+interface UseAlbumModalOptions {
+  /** 상태 소스: 사진 추가(NOTE) 또는 사진 수정(EDIT) */
+  stateSource?: StateSource;
+}
+
+const useAlbumModal = (options?: UseAlbumModalOptions) => {
+  const stateSource = options?.stateSource ?? STATE_SOURCE.NOTE;
+  const {
+    initialAlbumId,
+    setInitialAlbumId,
+    photoNoteState,
+    updatePhotoNoteState,
+    photoEditState,
+    updatePhotoEditState,
+  } = usePhotoContext();
+
+  const state = stateSource === STATE_SOURCE.EDIT ? photoEditState : photoNoteState;
+  const updateState =
+    stateSource === STATE_SOURCE.EDIT ? updatePhotoEditState : updatePhotoNoteState;
 
   const [tempSelectedAlbumId, setTempSelectedAlbumId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -14,17 +33,23 @@ const useAlbumModal = () => {
 
   const { data, isLoading } = useGetSelectableAlbums();
 
-  // 앨범 상세에서 진입 시 앨범 자동 선택
+  // 앨범 상세에서 진입 시 앨범 자동 선택 (note 모드에서만)
   // initialAlbumId 사용 후 바로 null로 설정하여 중복 실행 방지
   useEffect(() => {
-    if (initialAlbumId && data?.albums) {
+    if (stateSource === STATE_SOURCE.NOTE && initialAlbumId && data?.albums) {
       const album = data.albums.find((a) => a.id === initialAlbumId);
       if (album && album.id && album.title) {
         updatePhotoNoteState({ selectedAlbum: { id: album.id, title: album.title } });
       }
       setInitialAlbumId(null);
     }
-  }, [initialAlbumId, data?.albums, setInitialAlbumId, updatePhotoNoteState]);
+  }, [
+    stateSource,
+    initialAlbumId,
+    data?.albums,
+    setInitialAlbumId,
+    updatePhotoNoteState,
+  ]);
 
   const trimmedSearchQuery = searchQuery.trim();
 
@@ -39,7 +64,7 @@ const useAlbumModal = () => {
   );
 
   const openModal = () => {
-    setTempSelectedAlbumId(photoNoteState.selectedAlbum?.id ?? null);
+    setTempSelectedAlbumId(state.selectedAlbum?.id ?? null);
     setSearchQuery('');
     setIsOpen(true);
   };
@@ -49,21 +74,21 @@ const useAlbumModal = () => {
   };
 
   const resetAlbum = () => {
-    updatePhotoNoteState({ selectedAlbum: null });
+    updateState({ selectedAlbum: null });
   };
 
   const submitAlbum = () => {
     if (tempSelectedAlbumId && data?.albums) {
       const album = data.albums.find((a) => a.id === tempSelectedAlbumId);
       if (album && album.id && album.title) {
-        updatePhotoNoteState({ selectedAlbum: { id: album.id, title: album.title } });
+        updateState({ selectedAlbum: { id: album.id, title: album.title } });
       }
     }
     closeModal();
   };
 
   return {
-    selectedAlbum: photoNoteState.selectedAlbum,
+    selectedAlbum: state.selectedAlbum,
     tempSelectedAlbumId,
     setTempSelectedAlbumId,
     searchQuery,

--- a/apps/web/src/app/photo/add/note/_hooks/useAlbumModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useAlbumModal.ts
@@ -1,36 +1,30 @@
 'use client';
 
 import { useGetSelectableAlbums, type SelectableAlbum } from '@repo/api-client';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
 
-interface SelectedAlbum {
-  id: number;
-  title: string;
-}
-
 const useAlbumModal = () => {
-  const { initialAlbumId, setInitialAlbumId } = usePhotoContext();
-  const hasInitialized = useRef(false);
+  const { initialAlbumId, setInitialAlbumId, photoNoteState, updatePhotoNoteState } =
+    usePhotoContext();
 
-  const [selectedAlbum, setSelectedAlbum] = useState<SelectedAlbum | null>(null);
   const [tempSelectedAlbumId, setTempSelectedAlbumId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [isOpen, setIsOpen] = useState(false);
 
   const { data, isLoading } = useGetSelectableAlbums();
 
-  // 앨범 상세에서 진입 시 앨범 자동 선택 (최초 1회만)
+  // 앨범 상세에서 진입 시 앨범 자동 선택
+  // initialAlbumId 사용 후 바로 null로 설정하여 중복 실행 방지
   useEffect(() => {
-    if (initialAlbumId && data?.albums && !hasInitialized.current) {
+    if (initialAlbumId && data?.albums) {
       const album = data.albums.find((a) => a.id === initialAlbumId);
       if (album && album.id && album.title) {
-        setSelectedAlbum({ id: album.id, title: album.title });
-        hasInitialized.current = true;
-        setInitialAlbumId(null);
+        updatePhotoNoteState({ selectedAlbum: { id: album.id, title: album.title } });
       }
+      setInitialAlbumId(null);
     }
-  }, [initialAlbumId, data?.albums, setInitialAlbumId]);
+  }, [initialAlbumId, data?.albums, setInitialAlbumId, updatePhotoNoteState]);
 
   const trimmedSearchQuery = searchQuery.trim();
 
@@ -45,7 +39,7 @@ const useAlbumModal = () => {
   );
 
   const openModal = () => {
-    setTempSelectedAlbumId(selectedAlbum?.id ?? null);
+    setTempSelectedAlbumId(photoNoteState.selectedAlbum?.id ?? null);
     setSearchQuery('');
     setIsOpen(true);
   };
@@ -55,21 +49,21 @@ const useAlbumModal = () => {
   };
 
   const resetAlbum = () => {
-    setSelectedAlbum(null);
+    updatePhotoNoteState({ selectedAlbum: null });
   };
 
   const submitAlbum = () => {
     if (tempSelectedAlbumId && data?.albums) {
       const album = data.albums.find((a) => a.id === tempSelectedAlbumId);
       if (album && album.id && album.title) {
-        setSelectedAlbum({ id: album.id, title: album.title });
+        updatePhotoNoteState({ selectedAlbum: { id: album.id, title: album.title } });
       }
     }
     closeModal();
   };
 
   return {
-    selectedAlbum,
+    selectedAlbum: photoNoteState.selectedAlbum,
     tempSelectedAlbumId,
     setTempSelectedAlbumId,
     searchQuery,

--- a/apps/web/src/app/photo/add/note/_hooks/useAlbumModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useAlbumModal.ts
@@ -1,7 +1,8 @@
 'use client';
 
 import { useGetSelectableAlbums, type SelectableAlbum } from '@repo/api-client';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
 
 interface SelectedAlbum {
   id: number;
@@ -9,6 +10,9 @@ interface SelectedAlbum {
 }
 
 const useAlbumModal = () => {
+  const { initialAlbumId, setInitialAlbumId } = usePhotoContext();
+  const hasInitialized = useRef(false);
+
   const [selectedAlbum, setSelectedAlbum] = useState<SelectedAlbum | null>(null);
   const [tempSelectedAlbumId, setTempSelectedAlbumId] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -16,7 +20,17 @@ const useAlbumModal = () => {
 
   const { data, isLoading } = useGetSelectableAlbums();
 
-  // TODO: 앨범 상세에서 진입 시 또는 수정 화면에서 기존 앨범 자동 선택
+  // 앨범 상세에서 진입 시 앨범 자동 선택 (최초 1회만)
+  useEffect(() => {
+    if (initialAlbumId && data?.albums && !hasInitialized.current) {
+      const album = data.albums.find((a) => a.id === initialAlbumId);
+      if (album && album.id && album.title) {
+        setSelectedAlbum({ id: album.id, title: album.title });
+        hasInitialized.current = true;
+        setInitialAlbumId(null);
+      }
+    }
+  }, [initialAlbumId, data?.albums, setInitialAlbumId]);
 
   const trimmedSearchQuery = searchQuery.trim();
 

--- a/apps/web/src/app/photo/add/note/_hooks/useLocationModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useLocationModal.ts
@@ -4,25 +4,25 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { searchPlaces, getSearchPlacesQueryKey, PlaceResponse } from '@repo/api-client';
 import { useDebounce } from '@/hooks/useDebounce';
+import { usePhotoContext, type PhotoNoteState } from '@/app/photo/_contexts/PhotoContext';
 
 const DEBOUNCE_DELAY = 500;
 
+type SelectedLocation = PhotoNoteState['selectedLocation'];
+
 interface UseLocationModalOptions {
-  initialLocation?: Pick<PlaceResponse, 'latitude' | 'longitude' | 'address'> | null;
+  /** 로컬 상태 사용 (편집 화면용) */
+  useLocalState?: boolean;
 }
 
 const useLocationModal = (options?: UseLocationModalOptions) => {
-  const initialLocationState: PlaceResponse | null = options?.initialLocation
-    ? {
-        latitude: options.initialLocation.latitude,
-        longitude: options.initialLocation.longitude,
-        address: options.initialLocation.address,
-      }
-    : null;
+  const useLocalState = options?.useLocalState ?? false;
+  const { photoNoteState, updatePhotoNoteState } = usePhotoContext();
 
-  const [selectedLocation, setSelectedLocation] = useState<PlaceResponse | null>(
-    initialLocationState,
-  );
+  // 로컬 상태 (편집 화면용)
+  const [localSelectedLocation, setLocalSelectedLocation] =
+    useState<SelectedLocation>(null);
+
   const [tempSelectedLocationId, setTempSelectedLocationId] = useState<string | null>(
     null,
   );
@@ -38,6 +38,18 @@ const useLocationModal = (options?: UseLocationModalOptions) => {
   });
 
   const locations = data?.places ?? [];
+
+  const selectedLocation = useLocalState
+    ? localSelectedLocation
+    : photoNoteState.selectedLocation;
+
+  const setSelectedLocation = (location: SelectedLocation) => {
+    if (useLocalState) {
+      setLocalSelectedLocation(location);
+    } else {
+      updatePhotoNoteState({ selectedLocation: location });
+    }
+  };
 
   const openModal = () => {
     setTempSelectedLocationId(
@@ -59,7 +71,13 @@ const useLocationModal = (options?: UseLocationModalOptions) => {
         (l) => `${l.longitude}-${l.latitude}` === tempSelectedLocationId,
       );
       if (location) {
-        setSelectedLocation(location);
+        setSelectedLocation({
+          latitude: location.latitude,
+          longitude: location.longitude,
+          address: location.address,
+          roadAddress: location.roadAddress,
+          placeName: location.placeName,
+        });
       }
     }
     closeModal();

--- a/apps/web/src/app/photo/add/note/_hooks/useLocationModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useLocationModal.ts
@@ -2,26 +2,28 @@
 
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { searchPlaces, getSearchPlacesQueryKey, PlaceResponse } from '@repo/api-client';
+import { searchPlaces, getSearchPlacesQueryKey } from '@repo/api-client';
 import { useDebounce } from '@/hooks/useDebounce';
 import { usePhotoContext, type PhotoNoteState } from '@/app/photo/_contexts/PhotoContext';
+import { STATE_SOURCE, type StateSource } from '@/app/photo/_constants/stateSource';
 
 const DEBOUNCE_DELAY = 500;
 
 type SelectedLocation = PhotoNoteState['selectedLocation'];
 
 interface UseLocationModalOptions {
-  /** 로컬 상태 사용 (편집 화면용) */
-  useLocalState?: boolean;
+  /** 상태 소스: 사진 추가(NOTE) 또는 사진 수정(EDIT) */
+  stateSource?: StateSource;
 }
 
 const useLocationModal = (options?: UseLocationModalOptions) => {
-  const useLocalState = options?.useLocalState ?? false;
-  const { photoNoteState, updatePhotoNoteState } = usePhotoContext();
+  const stateSource = options?.stateSource ?? STATE_SOURCE.NOTE;
+  const { photoNoteState, updatePhotoNoteState, photoEditState, updatePhotoEditState } =
+    usePhotoContext();
 
-  // 로컬 상태 (편집 화면용)
-  const [localSelectedLocation, setLocalSelectedLocation] =
-    useState<SelectedLocation>(null);
+  const state = stateSource === STATE_SOURCE.EDIT ? photoEditState : photoNoteState;
+  const updateState =
+    stateSource === STATE_SOURCE.EDIT ? updatePhotoEditState : updatePhotoNoteState;
 
   const [tempSelectedLocationId, setTempSelectedLocationId] = useState<string | null>(
     null,
@@ -39,22 +41,14 @@ const useLocationModal = (options?: UseLocationModalOptions) => {
 
   const locations = data?.places ?? [];
 
-  const selectedLocation = useLocalState
-    ? localSelectedLocation
-    : photoNoteState.selectedLocation;
-
   const setSelectedLocation = (location: SelectedLocation) => {
-    if (useLocalState) {
-      setLocalSelectedLocation(location);
-    } else {
-      updatePhotoNoteState({ selectedLocation: location });
-    }
+    updateState({ selectedLocation: location });
   };
 
   const openModal = () => {
     setTempSelectedLocationId(
-      selectedLocation
-        ? `${selectedLocation.longitude}-${selectedLocation.latitude}`
+      state.selectedLocation
+        ? `${state.selectedLocation.longitude}-${state.selectedLocation.latitude}`
         : null,
     );
     setSearchQuery('');
@@ -84,7 +78,7 @@ const useLocationModal = (options?: UseLocationModalOptions) => {
   };
 
   return {
-    selectedLocation,
+    selectedLocation: state.selectedLocation,
     setSelectedLocation,
     tempSelectedLocationId,
     setTempSelectedLocationId,

--- a/apps/web/src/app/photo/add/note/_hooks/useMemoModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useMemoModal.ts
@@ -1,15 +1,31 @@
 import { useState, useEffect } from 'react';
+import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
 
-const useMemoModal = (initialMemo: string = '') => {
-  const [memo, setMemo] = useState(initialMemo);
-  const [tempMemo, setTempMemo] = useState(initialMemo);
+interface UseMemoModalOptions {
+  /** 로컬 상태 사용 (편집 화면용) */
+  initialMemo?: string;
+}
+
+const useMemoModal = (options?: UseMemoModalOptions) => {
+  const useLocalState = options?.initialMemo !== undefined;
+  const { photoNoteState, updatePhotoNoteState } = usePhotoContext();
+
+  // 로컬 상태 (편집 화면용)
+  const [localMemo, setLocalMemo] = useState(options?.initialMemo ?? '');
+  const [tempMemo, setTempMemo] = useState(
+    useLocalState ? (options?.initialMemo ?? '') : photoNoteState.memo,
+  );
   const [isOpen, setIsOpen] = useState(false);
 
-  // initialMemo가 변경될 때마다 상태 재설정
+  // initialMemo가 변경될 때 로컬 상태 업데이트 (편집 화면용)
   useEffect(() => {
-    setMemo(initialMemo);
-    setTempMemo(initialMemo);
-  }, [initialMemo]);
+    if (useLocalState && options?.initialMemo !== undefined) {
+      setLocalMemo(options.initialMemo);
+      setTempMemo(options.initialMemo);
+    }
+  }, [useLocalState, options?.initialMemo]);
+
+  const memo = useLocalState ? localMemo : photoNoteState.memo;
 
   const openModal = () => {
     setTempMemo(memo);
@@ -21,7 +37,11 @@ const useMemoModal = (initialMemo: string = '') => {
   };
 
   const submitMemo = () => {
-    setMemo(tempMemo);
+    if (useLocalState) {
+      setLocalMemo(tempMemo);
+    } else {
+      updatePhotoNoteState({ memo: tempMemo });
+    }
     closeModal();
   };
 
@@ -29,7 +49,6 @@ const useMemoModal = (initialMemo: string = '') => {
     memo,
     tempMemo,
     setTempMemo,
-    setMemo,
     isOpen,
     openModal,
     closeModal,

--- a/apps/web/src/app/photo/add/note/_hooks/useMemoModal.ts
+++ b/apps/web/src/app/photo/add/note/_hooks/useMemoModal.ts
@@ -1,34 +1,26 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
+import { STATE_SOURCE, type StateSource } from '@/app/photo/_constants/stateSource';
 
 interface UseMemoModalOptions {
-  /** 로컬 상태 사용 (편집 화면용) */
-  initialMemo?: string;
+  /** 상태 소스: 사진 추가(NOTE) 또는 사진 수정(EDIT) */
+  stateSource?: StateSource;
 }
 
 const useMemoModal = (options?: UseMemoModalOptions) => {
-  const useLocalState = options?.initialMemo !== undefined;
-  const { photoNoteState, updatePhotoNoteState } = usePhotoContext();
+  const stateSource = options?.stateSource ?? STATE_SOURCE.NOTE;
+  const { photoNoteState, updatePhotoNoteState, photoEditState, updatePhotoEditState } =
+    usePhotoContext();
 
-  // 로컬 상태 (편집 화면용)
-  const [localMemo, setLocalMemo] = useState(options?.initialMemo ?? '');
-  const [tempMemo, setTempMemo] = useState(
-    useLocalState ? (options?.initialMemo ?? '') : photoNoteState.memo,
-  );
+  const state = stateSource === STATE_SOURCE.EDIT ? photoEditState : photoNoteState;
+  const updateState =
+    stateSource === STATE_SOURCE.EDIT ? updatePhotoEditState : updatePhotoNoteState;
+
+  const [tempMemo, setTempMemo] = useState(state.memo);
   const [isOpen, setIsOpen] = useState(false);
 
-  // initialMemo가 변경될 때 로컬 상태 업데이트 (편집 화면용)
-  useEffect(() => {
-    if (useLocalState && options?.initialMemo !== undefined) {
-      setLocalMemo(options.initialMemo);
-      setTempMemo(options.initialMemo);
-    }
-  }, [useLocalState, options?.initialMemo]);
-
-  const memo = useLocalState ? localMemo : photoNoteState.memo;
-
   const openModal = () => {
-    setTempMemo(memo);
+    setTempMemo(state.memo);
     setIsOpen(true);
   };
 
@@ -37,16 +29,12 @@ const useMemoModal = (options?: UseMemoModalOptions) => {
   };
 
   const submitMemo = () => {
-    if (useLocalState) {
-      setLocalMemo(tempMemo);
-    } else {
-      updatePhotoNoteState({ memo: tempMemo });
-    }
+    updateState({ memo: tempMemo });
     closeModal();
   };
 
   return {
-    memo,
+    memo: state.memo,
     tempMemo,
     setTempMemo,
     isOpen,

--- a/apps/web/src/app/photo/add/page.tsx
+++ b/apps/web/src/app/photo/add/page.tsx
@@ -14,8 +14,14 @@ import * as S from './page.styles';
 
 export default function PhotoAddPage() {
   const router = useRouter();
-  const { photos, addPhotos, setSelectedPhoto, setSelectedPhotoRect, setInitialAlbumId } =
-    usePhotoContext();
+  const {
+    photos,
+    addPhotos,
+    setSelectedPhoto,
+    setSelectedPhotoRect,
+    setInitialAlbumId,
+    resetPhotoNoteState,
+  } = usePhotoContext();
 
   /**
    * 웹 브라우저 환경에서는 보안 정책상 사용자의 전체 갤러리에 접근할 수 없음.
@@ -30,11 +36,12 @@ export default function PhotoAddPage() {
       // 첫 번째 사진을 선택하고 바로 정보 기입 화면으로 이동
       if (newPhotos.length > 0) {
         setSelectedPhoto(newPhotos[0]);
+        resetPhotoNoteState();
         setInitialAlbumId(null);
         router.push(ROUTES.PHOTO.NOTE.ADD);
       }
     },
-    [addPhotos, setSelectedPhoto, setInitialAlbumId, router],
+    [addPhotos, setSelectedPhoto, resetPhotoNoteState, setInitialAlbumId, router],
   );
 
   const { isLoading, selectPhotosFromFile } = usePhotoSelect({
@@ -57,10 +64,17 @@ export default function PhotoAddPage() {
         height: rect.height,
       });
       setSelectedPhoto(photo);
+      resetPhotoNoteState();
       setInitialAlbumId(null);
       router.push(ROUTES.PHOTO.NOTE.ADD);
     },
-    [router, setSelectedPhoto, setSelectedPhotoRect, setInitialAlbumId],
+    [
+      router,
+      setSelectedPhoto,
+      setSelectedPhotoRect,
+      resetPhotoNoteState,
+      setInitialAlbumId,
+    ],
   );
 
   const handleAddPhotos = useCallback(() => {

--- a/apps/web/src/app/photo/add/page.tsx
+++ b/apps/web/src/app/photo/add/page.tsx
@@ -14,7 +14,8 @@ import * as S from './page.styles';
 
 export default function PhotoAddPage() {
   const router = useRouter();
-  const { photos, addPhotos, setSelectedPhoto, setSelectedPhotoRect } = usePhotoContext();
+  const { photos, addPhotos, setSelectedPhoto, setSelectedPhotoRect, setInitialAlbumId } =
+    usePhotoContext();
 
   /**
    * 웹 브라우저 환경에서는 보안 정책상 사용자의 전체 갤러리에 접근할 수 없음.
@@ -29,10 +30,11 @@ export default function PhotoAddPage() {
       // 첫 번째 사진을 선택하고 바로 정보 기입 화면으로 이동
       if (newPhotos.length > 0) {
         setSelectedPhoto(newPhotos[0]);
+        setInitialAlbumId(null);
         router.push(ROUTES.PHOTO.NOTE.ADD);
       }
     },
-    [addPhotos, setSelectedPhoto, router],
+    [addPhotos, setSelectedPhoto, setInitialAlbumId, router],
   );
 
   const { isLoading, selectPhotosFromFile } = usePhotoSelect({
@@ -55,9 +57,10 @@ export default function PhotoAddPage() {
         height: rect.height,
       });
       setSelectedPhoto(photo);
+      setInitialAlbumId(null);
       router.push(ROUTES.PHOTO.NOTE.ADD);
     },
-    [router, setSelectedPhoto, setSelectedPhotoRect],
+    [router, setSelectedPhoto, setSelectedPhotoRect, setInitialAlbumId],
   );
 
   const handleAddPhotos = useCallback(() => {

--- a/apps/web/src/app/photo/add/page.tsx
+++ b/apps/web/src/app/photo/add/page.tsx
@@ -60,8 +60,8 @@ export default function PhotoAddPage() {
     [router, setSelectedPhoto, setSelectedPhotoRect],
   );
 
-  const handleAddPhotos = useCallback(async () => {
-    await selectPhotosFromFile();
+  const handleAddPhotos = useCallback(() => {
+    selectPhotosFromFile();
   }, [selectPhotosFromFile]);
 
   if (isLoading && photos.length === 0) {

--- a/apps/web/src/app/photo/add/page.tsx
+++ b/apps/web/src/app/photo/add/page.tsx
@@ -36,7 +36,7 @@ export default function PhotoAddPage() {
       // 첫 번째 사진을 선택하고 바로 정보 기입 화면으로 이동
       if (newPhotos.length > 0) {
         setSelectedPhoto(newPhotos[0]);
-        resetPhotoNoteState();
+        resetPhotoNoteState(newPhotos[0]);
         setInitialAlbumId(null);
         router.push(ROUTES.PHOTO.NOTE.ADD);
       }
@@ -64,7 +64,7 @@ export default function PhotoAddPage() {
         height: rect.height,
       });
       setSelectedPhoto(photo);
-      resetPhotoNoteState();
+      resetPhotoNoteState(photo);
       setInitialAlbumId(null);
       router.push(ROUTES.PHOTO.NOTE.ADD);
     },

--- a/apps/web/src/app/photo/capture/page.tsx
+++ b/apps/web/src/app/photo/capture/page.tsx
@@ -13,7 +13,7 @@ type CameraFacing = 'user' | 'environment';
 
 export default function PhotoCapturePage() {
   const router = useRouter();
-  const { addPhotos, setSelectedPhoto } = usePhotoContext();
+  const { addPhotos, setSelectedPhoto, setInitialAlbumId } = usePhotoContext();
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -131,10 +131,19 @@ export default function PhotoCapturePage() {
     if (photo) {
       addPhotos([photo]);
       setSelectedPhoto(photo);
+      setInitialAlbumId(null);
       stopCamera();
       router.push(ROUTES.PHOTO.NOTE.ADD);
     }
-  }, [facingMode, currentLocation, addPhotos, setSelectedPhoto, stopCamera, router]);
+  }, [
+    facingMode,
+    currentLocation,
+    addPhotos,
+    setSelectedPhoto,
+    setInitialAlbumId,
+    stopCamera,
+    router,
+  ]);
 
   return (
     <S.Container>

--- a/apps/web/src/app/photo/capture/page.tsx
+++ b/apps/web/src/app/photo/capture/page.tsx
@@ -13,7 +13,8 @@ type CameraFacing = 'user' | 'environment';
 
 export default function PhotoCapturePage() {
   const router = useRouter();
-  const { addPhotos, setSelectedPhoto, setInitialAlbumId } = usePhotoContext();
+  const { addPhotos, setSelectedPhoto, setInitialAlbumId, resetPhotoNoteState } =
+    usePhotoContext();
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -131,6 +132,7 @@ export default function PhotoCapturePage() {
     if (photo) {
       addPhotos([photo]);
       setSelectedPhoto(photo);
+      resetPhotoNoteState();
       setInitialAlbumId(null);
       stopCamera();
       router.push(ROUTES.PHOTO.NOTE.ADD);
@@ -140,6 +142,7 @@ export default function PhotoCapturePage() {
     currentLocation,
     addPhotos,
     setSelectedPhoto,
+    resetPhotoNoteState,
     setInitialAlbumId,
     stopCamera,
     router,

--- a/apps/web/src/app/photo/capture/page.tsx
+++ b/apps/web/src/app/photo/capture/page.tsx
@@ -132,7 +132,7 @@ export default function PhotoCapturePage() {
     if (photo) {
       addPhotos([photo]);
       setSelectedPhoto(photo);
-      resetPhotoNoteState();
+      resetPhotoNoteState(photo);
       setInitialAlbumId(null);
       stopCamera();
       router.push(ROUTES.PHOTO.NOTE.ADD);

--- a/apps/web/src/components/bottomSheet/BottomSheet.tsx
+++ b/apps/web/src/components/bottomSheet/BottomSheet.tsx
@@ -40,7 +40,8 @@ const BottomSheet = ({
 }: BottomSheetProps) => {
   const router = useRouter();
   const [isDragging, setIsDragging] = useState(false);
-  const { addPhotos, setSelectedPhoto, setInitialAlbumId } = usePhotoContext();
+  const { addPhotos, setSelectedPhoto, setInitialAlbumId, resetPhotoNoteState } =
+    usePhotoContext();
 
   /**
    * 웹 브라우저 환경에서는 보안 정책상 사용자의 전체 갤러리에 접근할 수 없음.
@@ -54,13 +55,21 @@ const BottomSheet = ({
       addPhotos(newPhotos);
       if (newPhotos.length > 0) {
         setSelectedPhoto(newPhotos[0]);
+        resetPhotoNoteState();
         const albumId =
           context.type === SHEET_CONTEXT_TYPE.ALBUM_DETAIL ? context.albumId : null;
         setInitialAlbumId(albumId);
         router.push(ROUTES.PHOTO.NOTE.ADD);
       }
     },
-    [addPhotos, setSelectedPhoto, setInitialAlbumId, router, context],
+    [
+      addPhotos,
+      setSelectedPhoto,
+      resetPhotoNoteState,
+      setInitialAlbumId,
+      router,
+      context,
+    ],
   );
 
   const { selectPhotosFromFile } = usePhotoSelect({

--- a/apps/web/src/components/bottomSheet/BottomSheet.tsx
+++ b/apps/web/src/components/bottomSheet/BottomSheet.tsx
@@ -55,7 +55,7 @@ const BottomSheet = ({
       addPhotos(newPhotos);
       if (newPhotos.length > 0) {
         setSelectedPhoto(newPhotos[0]);
-        resetPhotoNoteState();
+        resetPhotoNoteState(newPhotos[0]);
         const albumId =
           context.type === SHEET_CONTEXT_TYPE.ALBUM_DETAIL ? context.albumId : null;
         setInitialAlbumId(albumId);

--- a/apps/web/src/components/bottomSheet/BottomSheet.tsx
+++ b/apps/web/src/components/bottomSheet/BottomSheet.tsx
@@ -40,7 +40,7 @@ const BottomSheet = ({
 }: BottomSheetProps) => {
   const router = useRouter();
   const [isDragging, setIsDragging] = useState(false);
-  const { addPhotos, setSelectedPhoto } = usePhotoContext();
+  const { addPhotos, setSelectedPhoto, setInitialAlbumId } = usePhotoContext();
 
   /**
    * 웹 브라우저 환경에서는 보안 정책상 사용자의 전체 갤러리에 접근할 수 없음.
@@ -54,10 +54,13 @@ const BottomSheet = ({
       addPhotos(newPhotos);
       if (newPhotos.length > 0) {
         setSelectedPhoto(newPhotos[0]);
+        const albumId =
+          context.type === SHEET_CONTEXT_TYPE.ALBUM_DETAIL ? context.albumId : null;
+        setInitialAlbumId(albumId);
         router.push(ROUTES.PHOTO.NOTE.ADD);
       }
     },
-    [addPhotos, setSelectedPhoto, router],
+    [addPhotos, setSelectedPhoto, setInitialAlbumId, router, context],
   );
 
   const { selectPhotosFromFile } = usePhotoSelect({

--- a/apps/web/src/mocks/MSWProvider.tsx
+++ b/apps/web/src/mocks/MSWProvider.tsx
@@ -11,7 +11,7 @@ export function MSWProvider({ children }: MSWProviderProps) {
 
   useEffect(() => {
     async function enableMocking() {
-      if (process.env.NODE_ENV !== 'development') {
+      if (process.env.NEXT_PUBLIC_ENABLE_MOCK !== 'true') {
         setIsReady(true);
         return;
       }


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #99 

## 🛠 2. 작업 내용

<img width="430" alt="스크린샷 2026-02-11 오전 12 13 26" src="https://github.com/user-attachments/assets/c8f8cce8-6065-4b1c-87dc-787004e1a658" />

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ] context에 상태가 덕지덕지 붙어있는데, 이걸 개선할 수 있는 방안이 있을까요?

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1.
2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 중복 렌더링된 위치 권한 모달을 제거했습니다.

* **변경**
  * 사진 선택 흐름을 동기 호출로 간소화하고, 단일 파일 선택 및 강력한 MIME 타입 검사(이미지 허용 목록)를 도입했습니다.
  * 파일 선택 취소 및 자원 정리를 강화하고 내부 옵션 참조 안정성을 개선했습니다.

* **새 기능**
  * 사진 컨텍스트에 초기 앨범 ID(initialAlbumId) 및 설정자(setInitialAlbumId)를 추가하여 선택/캡처 흐름에서 초기 앨범을 자동으로 적용·리셋합니다.
  * 하단 시트 및 캡처 화면에서 초기 앨범 정보가 전파됩니다.

* **환경 설정**
  * 모의 데이터 활성화를 전용 환경변수로 제어하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->