### PR TITLE
refactor: keep previous data

### DIFF
--- a/apps/web/src/components/common/crossfadeText/CrossfadeText.styles.ts
+++ b/apps/web/src/components/common/crossfadeText/CrossfadeText.styles.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+import { motion } from 'framer-motion';
+
+export const Container = styled.span`
+  position: relative;
+  display: inline-block;
+`;
+
+export const MotionText = styled(motion.span)`
+  display: inline-block;
+`;

--- a/apps/web/src/components/common/crossfadeText/CrossfadeText.tsx
+++ b/apps/web/src/components/common/crossfadeText/CrossfadeText.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { AnimatePresence } from 'framer-motion';
+import * as S from './CrossfadeText.styles';
+
+interface CrossfadeTextProps {
+  text: string;
+  className?: string;
+}
+
+const CrossfadeText = ({ text, className }: CrossfadeTextProps) => {
+  return (
+    <S.Container className={className}>
+      <AnimatePresence mode="popLayout" initial={false}>
+        <S.MotionText
+          key={text}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0, position: 'absolute', top: 0, left: 0, right: 0 }}
+          transition={{ duration: 0.25, ease: 'easeOut' }}
+        >
+          {text}
+        </S.MotionText>
+      </AnimatePresence>
+    </S.Container>
+  );
+};
+
+export default CrossfadeText;

--- a/apps/web/src/components/header/explore/ExploreHeader.tsx
+++ b/apps/web/src/components/header/explore/ExploreHeader.tsx
@@ -2,6 +2,7 @@ import ExploreIcon from '@/assets/images/explore.svg';
 import LocationIcon from '@/assets/images/location.svg';
 import ProfileIcon from '@/assets/images/profile.svg';
 import CircleButton from '@/components/buttons/circleButton/CircleButton';
+import CrossfadeText from '@/components/common/crossfadeText/CrossfadeText';
 import {
   BUTTON_SIZE,
   ICON_SIZE,
@@ -56,7 +57,9 @@ const ExploreHeader = ({
           <S.LocationIconWrapper>
             <LocationIcon width={16} height={16} />
           </S.LocationIconWrapper>
-          <S.LocationText>{title}</S.LocationText>
+          <S.LocationText>
+            <CrossfadeText text={title} />
+          </S.LocationText>
         </S.LocationWrapper>
       }
       right={

--- a/apps/web/src/components/header/menu/MenuHeader.tsx
+++ b/apps/web/src/components/header/menu/MenuHeader.tsx
@@ -3,6 +3,7 @@ import ChevronLeftIcon from '@/assets/images/chevronLeft.svg';
 import LocationIcon from '@/assets/images/location.svg';
 import MenuIcon from '@/assets/images/menu.svg';
 import CircleButton from '@/components/buttons/circleButton/CircleButton';
+import CrossfadeText from '@/components/common/crossfadeText/CrossfadeText';
 import { BUTTON_SIZE, ICON_SIZE } from '../base/Header.constants';
 import HeaderBase from '../base/HeaderBase';
 import * as B from '../base/Header.styles';
@@ -73,7 +74,11 @@ const MenuHeaderMain = ({
                   <LocationIcon width={16} height={16} />
                 </E.LocationIconWrapper>
               )}
-              {title && <B.Title>{title}</B.Title>}
+              {title && (
+                <B.Title>
+                  <CrossfadeText text={title} />
+                </B.Title>
+              )}
             </B.CenterSection>
           }
           right={

--- a/apps/web/src/components/image/ImagePin.tsx
+++ b/apps/web/src/components/image/ImagePin.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { motion } from 'framer-motion';
 import * as S from './ImagePin.styles';
 
 interface ImagePinProps {
@@ -11,13 +14,20 @@ interface ImagePinProps {
 
 const ImagePin = ({ imageUrl, imageCount, onClick }: ImagePinProps) => {
   return (
-    <S.PinButton onClick={onClick} type="button" aria-label="핀 상세 보기">
-      <S.ImageWrapper>
-        <S.StyledImage src={imageUrl} alt="pin-location" />
-        {imageCount > 1 && <S.Badge>{imageCount}</S.Badge>}
-      </S.ImageWrapper>
-      <S.Tail />
-    </S.PinButton>
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+    >
+      <S.PinButton onClick={onClick} type="button" aria-label="핀 상세 보기">
+        <S.ImageWrapper>
+          <S.StyledImage src={imageUrl} alt="pin-location" />
+          {imageCount > 1 && <S.Badge>{imageCount}</S.Badge>}
+        </S.ImageWrapper>
+        <S.Tail />
+      </S.PinButton>
+    </motion.div>
   );
 };
 

--- a/apps/web/src/components/map/MapView.tsx
+++ b/apps/web/src/components/map/MapView.tsx
@@ -4,6 +4,7 @@ import React, { useRef, forwardRef, useImperativeHandle, useEffect } from 'react
 import { Map, GeolocateControl, Marker } from 'react-map-gl/mapbox';
 import type { GeolocateControl as GeolocateControlInstance } from 'mapbox-gl';
 import type { MapRef } from 'react-map-gl/mapbox';
+import { AnimatePresence } from 'framer-motion';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { LocationState, MapPin } from '@/types/map.type';
 import * as S from './MapView.styels';
@@ -93,20 +94,22 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(
             position="bottom-right"
             style={{ display: 'none' }}
           />
-          {pins.map((pin) => (
-            <Marker
-              key={pin.isCluster ? pin.clusterId : pin.id}
-              latitude={pin.latitude}
-              longitude={pin.longitude}
-              anchor="bottom"
-            >
-              <ImagePin
-                imageUrl={pin.imageUrl}
-                imageCount={pin.imageCount}
-                onClick={() => onPinClick(pin)}
-              />
-            </Marker>
-          ))}
+          <AnimatePresence mode="sync">
+            {pins.map((pin) => (
+              <Marker
+                key={pin.isCluster ? pin.clusterId : pin.id}
+                latitude={pin.latitude}
+                longitude={pin.longitude}
+                anchor="bottom"
+              >
+                <ImagePin
+                  imageUrl={pin.imageUrl}
+                  imageCount={pin.imageCount}
+                  onClick={() => onPinClick(pin)}
+                />
+              </Marker>
+            ))}
+          </AnimatePresence>
         </Map>
       </S.Wrapper>
     );

--- a/apps/web/src/hooks/queries/useMapHomeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapHomeAlbums.ts
@@ -28,13 +28,16 @@ export const useMapHomeAlbums = ({ longitude, latitude }: UseMapHomeAlbumsParams
   const albumList: AlbumThumbnails[] = useMemo(() => {
     if (!isValid) return prevAlbumListRef.current;
 
-    const newAlbums = response.data?.albums ?? [];
-    if (newAlbums.length > 0) {
+    // API 요청이 성공하면 결과를 신뢰 (빈 배열도 유효한 결과)
+    if (response.data !== undefined) {
+      const newAlbums = response.data.albums ?? [];
       prevAlbumListRef.current = newAlbums;
       return newAlbums;
     }
+
+    // 로딩 중에는 이전 데이터 유지
     return prevAlbumListRef.current;
-  }, [response.data?.albums, isValid]);
+  }, [response.data, isValid]);
 
   // 새 주소가 있으면 캐싱, 로딩 중에는 이전 주소 유지
   const newAddress = response.data?.location?.address;

--- a/apps/web/src/hooks/queries/useMapHomeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapHomeAlbums.ts
@@ -1,4 +1,5 @@
-import { useGetMe, type AlbumThumbnails } from '@repo/api-client';
+import { getMe, getGetMeQueryKey, type AlbumThumbnails } from '@repo/api-client';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { useMemo, useRef } from 'react';
 
 interface UseMapHomeAlbumsParams {
@@ -9,17 +10,30 @@ interface UseMapHomeAlbumsParams {
 export const useMapHomeAlbums = ({ longitude, latitude }: UseMapHomeAlbumsParams) => {
   const isValid = longitude !== undefined && latitude !== undefined;
   const prevAddressRef = useRef<string>('');
+  const prevAlbumListRef = useRef<AlbumThumbnails[]>([]);
 
-  const response = useGetMe({
+  const params = {
     longitude: longitude ?? 0,
     latitude: latitude ?? 0,
     zoom: 0,
+  };
+
+  const response = useQuery({
+    queryKey: getGetMeQueryKey(params),
+    queryFn: ({ signal }) => getMe(params, signal),
+    enabled: isValid,
+    placeholderData: keepPreviousData,
   });
 
   const albumList: AlbumThumbnails[] = useMemo(() => {
-    if (!isValid) return [];
+    if (!isValid) return prevAlbumListRef.current;
 
-    return response.data?.albums ?? [];
+    const newAlbums = response.data?.albums ?? [];
+    if (newAlbums.length > 0) {
+      prevAlbumListRef.current = newAlbums;
+      return newAlbums;
+    }
+    return prevAlbumListRef.current;
   }, [response.data?.albums, isValid]);
 
   // 새 주소가 있으면 캐싱, 로딩 중에는 이전 주소 유지

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { getMe, getGetMeQueryKey } from '@repo/api-client';
 import { useMemo, useRef } from 'react';
 import Supercluster from 'supercluster';
@@ -11,7 +11,6 @@ import {
   extractClusterPhotoData,
   type ClusterPhotoResponse,
 } from './_utils/mapClustering.calc';
-
 
 interface UseMapMeParams {
   longitude?: number;
@@ -49,6 +48,7 @@ export const useMapMe = ({
     queryKey: getGetMeQueryKey(params),
     queryFn: ({ signal }) => getMe(params, signal),
     enabled: isValid,
+    placeholderData: keepPreviousData,
   });
 
   const address = useMemo(() => {
@@ -67,9 +67,7 @@ export const useMapMe = ({
   }, []);
 
   // 클러스터 확장 데이터를 캐싱하여 페이지 이동 후에도 유지
-  const clusterExpansionCacheRef = useRef<Map<string, ClusterPhotoResponse[]>>(
-    new Map()
-  );
+  const clusterExpansionCacheRef = useRef<Map<string, ClusterPhotoResponse[]>>(new Map());
 
   // 통합 클러스터링 계산 - mapPins와 clusterExpansionData를 한 번에 처리
   // 이전에는 이 로직이 두 개의 useMemo에서 중복되었음
@@ -173,10 +171,10 @@ export const useMapMe = ({
   );
 
   const clusterExpansionData = useMemo(
-    () => clusteringResult?.clusterExpansionData ?? new Map<string, ClusterPhotoResponse[]>(),
+    () =>
+      clusteringResult?.clusterExpansionData ?? new Map<string, ClusterPhotoResponse[]>(),
     [clusteringResult],
   );
-
 
   return {
     address,

--- a/apps/web/src/hooks/queries/useMapMeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapMeAlbums.ts
@@ -1,6 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { getMe, getGetMeQueryKey, type AlbumThumbnails } from '@repo/api-client';
-import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
 interface UseMapMeAlbumsParams {
@@ -42,6 +41,7 @@ export const useMapMeAlbums = ({
     queryKey: getGetMeQueryKey(params),
     queryFn: ({ signal }) => getMe(params, signal),
     enabled: isValid,
+    placeholderData: keepPreviousData,
   });
 
   // /map/me 응답에서 albums을 별도 쿼리 키로 저장
@@ -64,6 +64,7 @@ export const useMapMeAlbums = ({
       return data.albums ?? [];
     },
     enabled: isValid,
+    placeholderData: keepPreviousData,
   });
 
   const albumList: AlbumThumbnails[] = albumsResponse.data ?? [];


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- #102 

## 🛠 2. 작업 내용

<img width="447" height="56" alt="스크린샷 2026-02-14 오후 12 54 12" src="https://github.com/user-attachments/assets/0f7efeab-f908-4fb8-b51f-38b0f64e55b7" />

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ]

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1. deploy preview 접속
2. 홈 화면에서 지도 움직여보기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 헤더 및 탐색 제목에 크로스페이드 텍스트 애니메이션 추가
  * 지도 핀과 이미지의 핀 버튼에 진입/퇴장 페이드 애니메이션 적용

* **성능 개선**
  * 데이터 갱신 시 이전 결과를 유지하여 로드 중 UI 붕괴 감소
  * 앨범 목록/썸네일 캐싱 보완으로 지도 기반 데이터 표시 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->