### PR TITLE
refactor: api 중복 호출 및 bbox 제거

### DIFF
--- a/apps/web/src/app/_hooks/useAlbumAdd.ts
+++ b/apps/web/src/app/_hooks/useAlbumAdd.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ApiError, useCreate2 } from '@repo/api-client';
+import { ApiError, useCreate2, getGetMeQueryKey } from '@repo/api-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from '@/components/toast';
 import { getMapMeAlbumsQueryKey } from '@/hooks/queries/useMapMeAlbums';
@@ -21,8 +21,10 @@ const useAlbumAdd = (onSuccess?: () => void) => {
       { data: { title: nextTitle } },
       {
         onSuccess: () => {
+          // getMe 관련 모든 쿼리 invalidate (params 무관)
+          queryClient.invalidateQueries({ queryKey: getGetMeQueryKey() });
+          // 앨범 리스트 쿼리도 invalidate
           queryClient.invalidateQueries({ queryKey: getMapMeAlbumsQueryKey() });
-          queryClient.refetchQueries({ queryKey: getMapMeAlbumsQueryKey() });
           showToast('앨범이 생성되었어요');
           onSuccess?.();
         },

--- a/apps/web/src/app/_hooks/useMapRouteData.ts
+++ b/apps/web/src/app/_hooks/useMapRouteData.ts
@@ -21,7 +21,6 @@ import {
   SHEET_CONTEXT_TYPE,
   type SheetContext,
 } from '@/components/bottomSheet/constants';
-import { calculateBbox } from '../_utils/mapRoute.calc';
 
 interface UseMapRouteDataProps {
   viewState: LocationState | null;
@@ -54,7 +53,7 @@ export const useMapRouteData = ({
   sheetContext,
   selectedAlbumId,
 }: UseMapRouteDataProps): UseMapRouteDataReturn => {
-  // 선택된 앨범의 상세 정보 조회 (bbox 계산에 필요하므로 먼저 호출)
+  // 선택된 앨범의 상세 정보 조회
   const { albumDetail } = useAlbumPhotos(selectedAlbumId);
 
   // 선택된 앨범의 맵 정보 (중심 좌표) 조회
@@ -62,21 +61,11 @@ export const useMapRouteData = ({
     selectedAlbumId ?? 0,
   );
 
-  // 앨범이 선택되면 앨범의 boundingBox 사용, 아니면 현재 위치 기반 bbox 사용
-  const bbox = useMemo(() => {
-    if (selectedAlbumId && albumMapInfo?.boundingBox) {
-      const bb = albumMapInfo.boundingBox;
-      return `${bb.west},${bb.south},${bb.east},${bb.north}`;
-    }
-    return viewState ? calculateBbox(viewState) : '';
-  }, [selectedAlbumId, albumMapInfo?.boundingBox, viewState]);
-
   // 앨범 리스트 조회 (/map/me에서 albums만 별도 관리)
   const { albumList } = useMapMeAlbums({
     longitude: viewState?.longitude,
     latitude: viewState?.latitude,
     zoom: viewState?.zoom ?? DEFAULT_ZOOM,
-    bbox,
     albumId: selectedAlbumId,
   });
 
@@ -85,7 +74,6 @@ export const useMapRouteData = ({
     longitude: viewState?.longitude,
     latitude: viewState?.latitude,
     zoom: viewState?.zoom ?? DEFAULT_ZOOM,
-    bbox,
     albumId: selectedAlbumId,
   });
 

--- a/apps/web/src/app/_hooks/useMapRouteViewState.ts
+++ b/apps/web/src/app/_hooks/useMapRouteViewState.ts
@@ -57,7 +57,18 @@ export const useMapRouteViewState = (): UseMapRouteViewStateReturn => {
 
     // 새로운 타이머 설정 (500ms 후에 viewState 업데이트)
     viewStateChangeTimerRef.current = setTimeout(() => {
-      setViewState(newViewState);
+      setViewState((prevState) => {
+        // 값이 실제로 변경된 경우에만 업데이트
+        if (
+          !prevState ||
+          prevState.longitude !== newViewState.longitude ||
+          prevState.latitude !== newViewState.latitude ||
+          prevState.zoom !== newViewState.zoom
+        ) {
+          return newViewState;
+        }
+        return prevState;
+      });
     }, 500);
   }, []);
 

--- a/apps/web/src/components/map/MapView.tsx
+++ b/apps/web/src/components/map/MapView.tsx
@@ -73,7 +73,7 @@ const MapView = forwardRef<MapViewHandle, MapViewProps>(
           }}
           maxBounds={[
             [124.5, 31.1],
-            [131.9, 38.8],
+            [133, 40],
           ]}
           onMove={(evt) => {
             if (onViewStateChange) {

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -16,7 +16,6 @@ interface UseMapMeParams {
   longitude?: number;
   latitude?: number;
   zoom: number;
-  bbox?: string;
   albumId?: number | null;
 }
 
@@ -30,12 +29,24 @@ export const useMapMe = ({
   longitude,
   latitude,
   zoom,
-  bbox,
   albumId,
 }: UseMapMeParams) => {
   const isValid = longitude !== undefined && latitude !== undefined;
   const roundedZoom = Math.round(zoom);
   const [lastDataVersion, setLastDataVersion] = useState<number | undefined>(undefined);
+
+  // 클라이언트 측 클러스터링을 위한 bbox 계산 (longitude, latitude 기반)
+  const bbox = useMemo(() => {
+    if (longitude !== undefined && latitude !== undefined) {
+      const offset = 0.05;
+      const west = longitude - offset;
+      const south = latitude - offset;
+      const east = longitude + offset;
+      const north = latitude + offset;
+      return `${west},${south},${east},${north}`;
+    }
+    return '';
+  }, [longitude, latitude]);
 
   const params = useMemo(
     () => ({

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -16,7 +16,7 @@ interface UseMapMeParams {
   longitude?: number;
   latitude?: number;
   zoom: number;
-  bbox: string;
+  bbox?: string;
   albumId?: number | null;
 }
 
@@ -33,7 +33,7 @@ export const useMapMe = ({
   bbox,
   albumId,
 }: UseMapMeParams) => {
-  const isValid = !!(longitude !== undefined && latitude !== undefined && bbox);
+  const isValid = !!(longitude !== undefined && latitude !== undefined);
   const roundedZoom = Math.round(zoom);
   const [lastDataVersion, setLastDataVersion] = useState<number | undefined>(undefined);
 
@@ -42,10 +42,9 @@ export const useMapMe = ({
       longitude: longitude ?? 0,
       latitude: latitude ?? 0,
       zoom: roundedZoom,
-      bbox: bbox || '',
       ...(albumId ? { albumId } : {}),
     }),
-    [longitude, latitude, roundedZoom, bbox, albumId],
+    [longitude, latitude, roundedZoom, albumId],
   );
 
 
@@ -130,7 +129,7 @@ export const useMapMe = ({
     superclusterInstance.load(geoJsonPoints as any);
 
     // bbox 파싱 (헬퍼 함수 사용)
-    const bboxValues = parseBbox(bbox);
+    const bboxValues = parseBbox(bbox ?? '');
     if (!bboxValues) {
       // bbox가 없으면 개별 핀으로 반환
       const photoPins: MapPin[] = photos.map((photo) => ({
@@ -177,7 +176,7 @@ export const useMapMe = ({
     clusterExpansionCacheRef.current = mergedClusterExpansionData;
 
     return { mapPins, clusterExpansionData: mergedClusterExpansionData };
-  }, [response.data, roundedZoom, bbox, superclusterInstance]);
+  }, [response.data, roundedZoom, bbox ?? '', superclusterInstance]);
 
   // 개별 값 추출 (메모이제이션으로 불필요한 리렌더링 방지)
   const mapPins: MapPin[] = useMemo(

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -37,27 +37,34 @@ export const useMapMe = ({
   const roundedZoom = Math.round(zoom);
   const [lastDataVersion, setLastDataVersion] = useState<number | undefined>(undefined);
 
-  const params = {
-    longitude: longitude ?? 0,
-    latitude: latitude ?? 0,
-    zoom: roundedZoom,
-    bbox: bbox || '',
-    ...(albumId ? { albumId } : {}),
-    ...(lastDataVersion ? { lastDataVersion } : {}),
-  };
+  const params = useMemo(
+    () => ({
+      longitude: longitude ?? 0,
+      latitude: latitude ?? 0,
+      zoom: roundedZoom,
+      bbox: bbox || '',
+      ...(albumId ? { albumId } : {}),
+    }),
+    [longitude, latitude, roundedZoom, bbox, albumId],
+  );
+
 
   const response = useQuery({
     queryKey: getGetMeQueryKey(params),
-    queryFn: ({ signal }) => getMe(params, signal),
+    queryFn: ({ signal }) => {
+      const requestParams = lastDataVersion ? { ...params, lastDataVersion } : params;
+      return getMe(requestParams, signal);
+    },
     enabled: isValid,
     placeholderData: keepPreviousData,
   });
 
+
   useEffect(() => {
-    if (response.data?.dataVersion !== undefined) {
+    if (response.data?.dataVersion !== undefined && response.data.dataVersion !== lastDataVersion) {
       setLastDataVersion(response.data.dataVersion);
     }
-  }, [response.data?.dataVersion]);
+  }, [response.data?.dataVersion, lastDataVersion]);
 
   const address = useMemo(() => {
     if (!isValid) return '';

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -33,7 +33,7 @@ export const useMapMe = ({
   bbox,
   albumId,
 }: UseMapMeParams) => {
-  const isValid = !!(longitude !== undefined && latitude !== undefined);
+  const isValid = longitude !== undefined && latitude !== undefined;
   const roundedZoom = Math.round(zoom);
   const [lastDataVersion, setLastDataVersion] = useState<number | undefined>(undefined);
 

--- a/apps/web/src/hooks/queries/useMapMeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapMeAlbums.ts
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { getMe, getGetMeQueryKey, type AlbumThumbnails } from '@repo/api-client';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 interface UseMapMeAlbumsParams {
   longitude?: number;
@@ -28,13 +28,16 @@ export const useMapMeAlbums = ({
   const queryClient = useQueryClient();
   const roundedZoom = Math.round(zoom);
 
-  const params = {
-    longitude: longitude ?? 0,
-    latitude: latitude ?? 0,
-    zoom: roundedZoom,
-    bbox: bbox || '',
-    ...(albumId ? { albumId } : {}),
-  };
+  const params = useMemo(
+    () => ({
+      longitude: longitude ?? 0,
+      latitude: latitude ?? 0,
+      zoom: roundedZoom,
+      bbox: bbox || '',
+      ...(albumId ? { albumId } : {}),
+    }),
+    [longitude, latitude, roundedZoom, bbox, albumId],
+  );
 
   // /map/me 데이터 가져오기 (백그라운드)
   const mapMeResponse = useQuery({
@@ -45,6 +48,7 @@ export const useMapMeAlbums = ({
   });
 
   // /map/me 응답에서 albums을 별도 쿼리 키로 저장
+  // invalidate되면 이 쿼리가 자동으로 refetch됨
   useEffect(() => {
     if (mapMeResponse.data?.albums) {
       queryClient.setQueryData(
@@ -54,25 +58,12 @@ export const useMapMeAlbums = ({
     }
   }, [mapMeResponse.data?.albums, queryClient]);
 
-  // ['mapMe', 'albums'] 쿼리를 직접 구독
-  // invalidate되면 이 쿼리가 자동으로 refetch됨
-  const albumsResponse = useQuery({
-    queryKey: getMapMeAlbumsQueryKey(),
-    queryFn: async () => {
-      // /map/me를 호출해서 albums 데이터만 추출
-      const data = await getMe(params);
-      return data.albums ?? [];
-    },
-    enabled: isValid,
-    placeholderData: keepPreviousData,
-  });
-
-  const albumList: AlbumThumbnails[] = albumsResponse.data ?? [];
+  const albumList: AlbumThumbnails[] = mapMeResponse.data?.albums ?? [];
 
   return {
     albumList,
-    isLoading: albumsResponse.isLoading,
-    isError: albumsResponse.isError,
-    error: albumsResponse.error,
+    isLoading: mapMeResponse.isLoading,
+    isError: mapMeResponse.isError,
+    error: mapMeResponse.error,
   };
 };

--- a/apps/web/src/hooks/queries/useMapMeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapMeAlbums.ts
@@ -21,10 +21,9 @@ export const useMapMeAlbums = ({
   longitude,
   latitude,
   zoom,
-  bbox,
   albumId,
 }: UseMapMeAlbumsParams) => {
-  const isValid = !!(longitude !== undefined && latitude !== undefined);
+  const isValid = longitude !== undefined && latitude !== undefined;
   const queryClient = useQueryClient();
   const roundedZoom = Math.round(zoom);
 

--- a/apps/web/src/hooks/queries/useMapMeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapMeAlbums.ts
@@ -6,7 +6,7 @@ interface UseMapMeAlbumsParams {
   longitude?: number;
   latitude?: number;
   zoom: number;
-  bbox: string;
+  bbox?: string;
   albumId?: number | null;
 }
 
@@ -24,7 +24,7 @@ export const useMapMeAlbums = ({
   bbox,
   albumId,
 }: UseMapMeAlbumsParams) => {
-  const isValid = !!(longitude !== undefined && latitude !== undefined && bbox);
+  const isValid = !!(longitude !== undefined && latitude !== undefined);
   const queryClient = useQueryClient();
   const roundedZoom = Math.round(zoom);
 
@@ -33,10 +33,9 @@ export const useMapMeAlbums = ({
       longitude: longitude ?? 0,
       latitude: latitude ?? 0,
       zoom: roundedZoom,
-      bbox: bbox || '',
       ...(albumId ? { albumId } : {}),
     }),
-    [longitude, latitude, roundedZoom, bbox, albumId],
+    [longitude, latitude, roundedZoom, albumId],
   );
 
   // /map/me 데이터 가져오기 (백그라운드)

--- a/apps/web/src/hooks/queries/useMapMeAlbums.ts
+++ b/apps/web/src/hooks/queries/useMapMeAlbums.ts
@@ -6,7 +6,6 @@ interface UseMapMeAlbumsParams {
   longitude?: number;
   latitude?: number;
   zoom: number;
-  bbox?: string;
   albumId?: number | null;
 }
 


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #106 

## 🛠 2. 작업 내용

- api 중복 호출과 지도화면이 제랜더링 되는 기준을 수정하였습니다.
- bbox 가 이제 map/me에서 필요하지 않으므로 제거하였습니다.

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->


## 🧪 5. 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **버그 수정**
  * 앨범 생성 이후 관련 데이터 갱신 방식을 전체 무효화로 개선해 관련 조회들을 최신 상태로 유지
  * 지도 뷰 상태 업데이트에서 불필요한 재렌더링 방지

* **리팩토링**
  * 지도/앨범 조회 흐름 단순화 — bbox 의존 제거 및 클라이언트 측 처리로 데이터 흐름 정리
  * 앨범 목록과 지도 데이터 로딩·캐시 동기화 개선

* **기능 개선**
  * 지도 패닝 허용 범위(맥스 바운드) 확장으로 더 넓은 지역 탐색 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->