### PR TITLE
refactor: /confirm 대신 /join 사용하도록 수정

### DIFF
--- a/apps/web/src/app/onboarding/_hooks/useCodeVerification.ts
+++ b/apps/web/src/app/onboarding/_hooks/useCodeVerification.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   useVerifyInviteCode,
-  useConfirmInviteCode,
+  useJoinByInviteCode,
   getGetMyStatusQueryKey,
   ApiError,
 } from '@repo/api-client';
@@ -13,7 +13,7 @@ import type { VerifyCodeResult } from '../_types';
 export function useCodeVerification() {
   const queryClient = useQueryClient();
   const { mutateAsync: verify, isPending: isVerifying } = useVerifyInviteCode();
-  const { mutateAsync: confirm, isPending: isConfirming } = useConfirmInviteCode();
+  const { mutateAsync: confirm, isPending: isConfirming } = useJoinByInviteCode();
 
   const verifyCode = useCallback(
     async (code: string): Promise<VerifyCodeResult> => {

--- a/apps/web/src/app/onboarding/_hooks/useCodeVerification.ts
+++ b/apps/web/src/app/onboarding/_hooks/useCodeVerification.ts
@@ -31,10 +31,10 @@ export function useCodeVerification() {
     [verify],
   );
 
-  const confirmCode = useCallback(
+  const joinCode = useCallback(
     async (code: string) => {
       try {
-        await confirm({ data: { inviteCode: code } });
+        await join({ data: { inviteCode: code } });
         queryClient.invalidateQueries({ queryKey: getGetMyStatusQueryKey() });
         return { success: true };
       } catch (error) {
@@ -45,13 +45,13 @@ export function useCodeVerification() {
         return { success: false, errorCode: 'UNKNOWN_ERROR' };
       }
     },
-    [confirm, queryClient],
+    [join, queryClient],
   );
 
   return {
     verifyCode,
-    confirmCode,
+    joinCode,
     isVerifying,
-    isConfirming,
+    isJoining,
   };
 }

--- a/apps/web/src/app/onboarding/_hooks/useCodeVerification.ts
+++ b/apps/web/src/app/onboarding/_hooks/useCodeVerification.ts
@@ -13,7 +13,7 @@ import type { VerifyCodeResult } from '../_types';
 export function useCodeVerification() {
   const queryClient = useQueryClient();
   const { mutateAsync: verify, isPending: isVerifying } = useVerifyInviteCode();
-  const { mutateAsync: confirm, isPending: isConfirming } = useJoinByInviteCode();
+  const { mutateAsync: join, isPending: isJoining } = useJoinByInviteCode();
 
   const verifyCode = useCallback(
     async (code: string): Promise<VerifyCodeResult> => {

--- a/apps/web/src/app/onboarding/verify/page.tsx
+++ b/apps/web/src/app/onboarding/verify/page.tsx
@@ -25,7 +25,7 @@ export default function VerifyPage() {
   const [hasProfileImageError, setHasProfileImageError] = useState(false);
   const { verifiedPartner, setVerifiedPartner, markStepCompleted } =
     useOnboardingContext();
-  const { verifyCode, confirmCode, isConfirming } = useCodeVerification();
+  const { verifyCode, joinCode, isJoining } = useCodeVerification();
 
   // 뒤로가기 시 재검증 방지
   const hasVerifiedRef = useRef(false);
@@ -73,7 +73,7 @@ export default function VerifyPage() {
   );
 
   const handleConfirm = useCallback(async () => {
-    const result = await confirmCode(code);
+    const result = await joinCode(code);
     if (result.success) {
       markStepCompleted('verify');
 
@@ -84,7 +84,7 @@ export default function VerifyPage() {
       showToast('잘못된 코드예요', 3000, 'warn');
       handleRetry();
     }
-  }, [code, confirmCode, markStepCompleted, router, showToast, handleRetry]);
+  }, [code, joinCode, markStepCompleted, router, showToast, handleRetry]);
 
   const handleNotFriendRetry = useCallback(() => {
     setIsNotFriendModalOpen(false);
@@ -128,7 +128,7 @@ export default function VerifyPage() {
               text="함께할래요!"
               variant="highlight"
               onClick={handleConfirm}
-              disabled={isConfirming}
+              disabled={isJoining}
             />
           </S.ButtonGroup>
         </S.Container>


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #129 

## 🛠 2. 작업 내용

- 온보딩에서 /confirm api가 제거됨에 따라 /join을 사용하도록 수정

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ]

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1.
2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 초대 코드 검증 관련 내부 구현을 정리했습니다. 내부 호출과 상태표시 방식이 개선되었지만 검증 흐름과 오류 처리, 사용자 경험은 변경되지 않았습니다.
  * 공개된 훅의 반환 속성 이름이 일부 변경되어 컴포넌트 내 사용 참조가 일관되게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->