### PR TITLE
refactor: 현재 환경 구분 추가

### DIFF
--- a/apps/web/src/app/onboarding/connect/page.tsx
+++ b/apps/web/src/app/onboarding/connect/page.tsx
@@ -111,7 +111,7 @@ export default function ConnectPage() {
     const kakao = window.Kakao;
     if (kakao && inviteCode?.code) {
       try {
-        const isDev = process.env.NODE_ENV === 'development';
+        const isDev = process.env.NEXT_PUBLIC_APP_ENV !== 'production';
         const templateId = isDev ? KAKAO_TEMPLATE_ID.DEV : KAKAO_TEMPLATE_ID.PROD;
 
         if (!templateId) {

--- a/apps/web/src/app/onboarding/verify/page.styles.ts
+++ b/apps/web/src/app/onboarding/verify/page.styles.ts
@@ -106,6 +106,7 @@ export const Title = styled.h1`
   color: #ffffff;
   text-align: center;
   margin: 0;
+  white-space: pre-line;
 `;
 
 export const Description = styled.p`

--- a/apps/web/src/app/onboarding/verify/page.tsx
+++ b/apps/web/src/app/onboarding/verify/page.tsx
@@ -146,10 +146,7 @@ export default function VerifyPage() {
     <S.Container>
       <OnboardingHeader />
       <S.Content>
-        <S.Title>친구 코드 입력</S.Title>
-        <S.Description>
-          친구에게 받은 {INVITE_CODE_LENGTH}자리 코드를 입력하세요
-        </S.Description>
+        <S.Title>{`파트너에게 받은 코드를\n입력해주세요`}</S.Title>
         <CodeInput value={code} onChange={setCode} onComplete={handleCodeComplete} />
       </S.Content>
 

--- a/apps/web/src/app/reconnect/_clientBoundary/KakaoShareClient/KakaoShareClient.tsx
+++ b/apps/web/src/app/reconnect/_clientBoundary/KakaoShareClient/KakaoShareClient.tsx
@@ -17,7 +17,7 @@ export default function KakaoShareClient({ inviteCode }: KakaoShareClientProps) 
     const kakao = window.Kakao;
     if (kakao && inviteCode) {
       try {
-        const isDev = process.env.NODE_ENV === 'development';
+        const isDev = process.env.NEXT_PUBLIC_APP_ENV !== 'production';
         const templateId = isDev ? KAKAO_TEMPLATE_ID.DEV : KAKAO_TEMPLATE_ID.PROD;
 
         if (!templateId) {

--- a/apps/web/src/constants/cookie.ts
+++ b/apps/web/src/constants/cookie.ts
@@ -1,4 +1,4 @@
-const COOKIE_PREFIX = process.env.NODE_ENV === 'development' ? 'dev-' : '';
+const COOKIE_PREFIX = process.env.NEXT_PUBLIC_APP_ENV === 'production' ? '' : 'dev-';
 
 export const ACCESS_TOKEN_COOKIE = `${COOKIE_PREFIX}accessToken`;
 export const COUPLE_STATUS_COOKIE = `${COOKIE_PREFIX}coupleStatus`;

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NEXT_PUBLIC_APP_ENV === 'production') {
   if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
     throw new Error('NEXT_PUBLIC_SENTRY_DSN is not defined');
   }


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #148 

## 🛠 2. 작업 내용

- 기존에는 NODE_ENV로 환경을 구분했으나, Netlify 배포 환경에서는 개발/운영 모두 production으로 인식되는 문제가 있었습니다.
이에 따라 NEXT_PUBLIC_APP_ENV를 도입해 애플리케이션 실행 환경을 명시적으로 주입하도록 변경했고, 관련 환경 변수도 설정했습니다.

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ]

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1.
2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 환경 감지 로직을 NEXT_PUBLIC_APP_ENV 기반으로 변경하여 카카오 공유 템플릿 선택, 쿠키 접두사, 모니터링 초기화 동작을 환경에 맞게 조정했습니다.
* **UI**
  * 온보딩 인증 화면의 제목 문구를 "파트너에게 받은 코드를 입력해주세요"로 변경했습니다.
* **Style**
  * 인증 페이지 제목에 줄바꿈 보존을 위한 white-space: pre-line 스타일을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->